### PR TITLE
Introducing Colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ A full-screen scrollable overlay with a comprehensive overview of your reading h
 
 Available everywhere (book view and file manager).
 
+
+**Controls:** tap to toggle between percentage/page view, long-press to force-reload data.
+
+**Caching:** shares the same stale-while-revalidate approach as Reading insights — instant open with cached data, refreshed in the background.
+
+---
+
 ### 📖 Book progress stats
 
 <img width="384" height="512" alt="Reader_Az Elso Torveny vilaga 1  - Hidegen talalva - Abercrombie, Joe #p(878) epub_p1117_2026-07-06_084654" src="https://github.com/user-attachments/assets/555ab8c6-d9ce-4ebc-a6ac-cfdf097ec51d" />
@@ -40,9 +47,9 @@ A per-book overlay showing detailed progress and pace for the book you're curren
 - **Session stats** — time spent reading this book today and across recent sessions
 - **Chapter breakdown** — progress and time spent per chapter (if chapter metadata is available)
 
-**Controls:** tap to toggle between percentage/page view, long-press to force-reload data.
+**Controls:** tap on "This Book" opens statistics plugin book stat screen.
 
-**Caching:** shares the same stale-while-revalidate approach as Reading insights — instant open with cached data, refreshed in the background.
+---
 
 ## Install
 
@@ -57,8 +64,15 @@ A per-book overlay showing detailed progress and pace for the book you're curren
 ## Where it shows up
 
 - **Menu:** *Tools → Reading insights* — a submenu with "Show Reading
-  insights", "Reading statistics: overview" (book view only), and the two
-  settings toggles below.
+  insights", "Show Book progress" (book view only), and, below a
+  separator, a **Settings** submenu holding the two options below plus a
+  **Colors** submenu:
+  - **Full-screen refresh on open/close** — toggle
+  - **8-week chart order** — newest-first or oldest-first
+  - **Colors** — pick your own hex color for every bar/line/label the two
+    popups draw (active/inactive bars, the 8-week trend line, and the
+    label/value/section/chart-label text colors); each one can be reset
+    back to its black-on-gray default individually or all at once.
 - **Gestures/shortcuts:** both popups are registered with `Dispatcher`, so
   they can be assigned under *Settings → Taps and gestures*:
   - `reading_insights_popup` — available everywhere (general action).
@@ -71,6 +85,9 @@ A per-book overlay showing detailed progress and pace for the book you're curren
   both views, registers the two dispatcher actions, builds the Tools menu.
 - `l10n.lua` — shared translation lookup (`l10n/<lang>.po`) and locale-aware
   number formatting, used by both views.
+- `colors.lua` — shared chart/text color settings (the "Colors" submenu)
+  used by both views, so there's a single place to configure every
+  color.
 - `insights_view.lua` — the full-screen "Reading insights" popup.
 - `stats_view.lua` — the compact "Reading statistics: overview" popup.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ More screenshots
 This plugin bundles two reading-stats popups, powered by KOReader's
 statistics database.
 
+### Reading insights (full-screen history)
+
 A full-screen scrollable overlay with a comprehensive overview of your reading history.
 
 **Highlights:**
@@ -25,12 +27,6 @@ A full-screen scrollable overlay with a comprehensive overview of your reading h
 
 Available everywhere (book view and file manager).
 
-**Controls:** tap to toggle between percentage/page view, long-press to force-reload data.
-
-**Caching:** shares the same stale-while-revalidate approach as Reading insights — instant open with cached data, refreshed in the background.
-
----
-
 ### 📖 Book progress stats
 
 <img width="384" height="512" alt="Reader_Az Elso Torveny vilaga 1  - Hidegen talalva - Abercrombie, Joe #p(878) epub_p1117_2026-07-06_084654" src="https://github.com/user-attachments/assets/555ab8c6-d9ce-4ebc-a6ac-cfdf097ec51d" />
@@ -44,7 +40,9 @@ A per-book overlay showing detailed progress and pace for the book you're curren
 - **Session stats** — time spent reading this book today and across recent sessions
 - **Chapter breakdown** — progress and time spent per chapter (if chapter metadata is available)
 
----
+**Controls:** tap to toggle between percentage/page view, long-press to force-reload data.
+
+**Caching:** shares the same stale-while-revalidate approach as Reading insights — instant open with cached data, refreshed in the background.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,6 @@ A full-screen scrollable overlay with a comprehensive overview of your reading h
 
 Available everywhere (book view and file manager).
 
-
-**Controls:** tap to toggle between percentage/page view, long-press to force-reload data.
-
-**Caching:** shares the same stale-while-revalidate approach as Reading insights — instant open with cached data, refreshed in the background.
-
----
-
 ### 📖 Book progress stats
 
 <img width="384" height="512" alt="Reader_Az Elso Torveny vilaga 1  - Hidegen talalva - Abercrombie, Joe #p(878) epub_p1117_2026-07-06_084654" src="https://github.com/user-attachments/assets/555ab8c6-d9ce-4ebc-a6ac-cfdf097ec51d" />
@@ -47,9 +40,9 @@ A per-book overlay showing detailed progress and pace for the book you're curren
 - **Session stats** — time spent reading this book today and across recent sessions
 - **Chapter breakdown** — progress and time spent per chapter (if chapter metadata is available)
 
-**Controls:** tap on "This Book" opens statistics plugin book stat screen.
+**Controls:** tap to toggle between percentage/page view, long-press to force-reload data.
 
----
+**Caching:** shares the same stale-while-revalidate approach as Reading insights — instant open with cached data, refreshed in the background.
 
 ## Install
 
@@ -70,9 +63,10 @@ A per-book overlay showing detailed progress and pace for the book you're curren
   - **Full-screen refresh on open/close** — toggle
   - **8-week chart order** — newest-first or oldest-first
   - **Colors** — pick your own hex color for every bar/line/label the two
-    popups draw (active/inactive bars, the 8-week trend line, and the
-    label/value/section/chart-label text colors); each one can be reset
-    back to its black-on-gray default individually or all at once.
+    popups draw (active/inactive bars, the 8-week trend line, section/
+    column separator lines, and the label/value/section/chart-label text
+    colors); each one can be reset back to its black-on-gray default
+    individually or all at once.
 - **Gestures/shortcuts:** both popups are registered with `Dispatcher`, so
   they can be assigned under *Settings → Taps and gestures*:
   - `reading_insights_popup` — available everywhere (general action).

--- a/colors.lua
+++ b/colors.lua
@@ -1,0 +1,253 @@
+--[[
+Reading Insights - shared chart/text color settings.
+
+Centralises the color choices used by both views (insights_view.lua and
+stats_view.lua), so there is exactly one "Colors" menu and one set of
+settings driving every chart/diagram and label in the plugin:
+
+  active_bar    "current" bar/point in a chart (today's bar, the current
+                month, the current chapter's read portion, the trend dot)
+  inactive_bar  every other bar/point, and chart baselines
+  trend_line    the connecting line in the "last 8 weeks" trend chart
+  label         "label" font role   (units/descriptions next to a value)
+  value         "value" font role   (the big numbers)
+  section       "section" font role (section headers, year header)
+  small         "small" font role   (chart axis/value labels, small print)
+
+Colors are stored as "#RRGGBB" hex strings in G_reader_settings - the same
+format KOReader itself accepts (see Blitbuffer.colorFromString), so any
+hex code the user can look up (a website color picker, another app, ...)
+works here too.
+
+Loaded by main.lua via loadfile(...)( L10N ) and handed straight to both
+view modules as their second chunk argument (alongside L10N), so
+`local L10N, Colors = ...` at the top of each view is all they need.
+
+Exposes:
+  getColor(key)         Blitbuffer color object, ready to use as
+                         fgcolor/background/line_color/etc.
+  activeBar() / inactiveBar() / label() / value() / section() / small()
+                         same as getColor(key), one shorthand per key
+  getHex(key)            current "#RRGGBB" value
+  getDefaultHex(key)      the original in-code default, unaffected by settings
+  setHex(key, hex)       validate + persist; returns true/false
+  resetToDefault(key)    restore the original in-code default
+  buildMenu(on_change)   KOReader sub_item_table for the "Colors" menu;
+                         on_change() is called after any color is changed
+                         or reset, so the caller can refresh open popups
+]]--
+
+local Blitbuffer  = require("ffi/blitbuffer")
+local ConfirmBox  = require("ui/widget/confirmbox")
+local InfoMessage = require("ui/widget/infomessage")
+local InputDialog = require("ui/widget/inputdialog")
+local UIManager    = require("ui/uimanager")
+
+local L10N = ...
+local _ = L10N._
+
+-- Order the "Colors" menu is built in.
+local KEY_ORDER = { "active_bar", "inactive_bar", "trend_line", "label", "value", "section", "small" }
+
+-- These match what was previously hard-coded directly in the two view
+-- files (Blitbuffer.COLOR_BLACK = "#000000", Blitbuffer.COLOR_GRAY = "#AAAAAA"),
+-- so upgrading the plugin changes nothing visually until the user opens
+-- the new Colors menu and picks something else.
+local DEFAULTS = {
+    active_bar   = "#000000",
+    inactive_bar = "#AAAAAA",
+    trend_line   = "#000000",
+    label        = "#000000",
+    value        = "#000000",
+    section      = "#000000",
+    small        = "#000000",
+}
+
+local SETTINGS_PREFIX = "reading_insights_color_"
+
+local function normalizeHex(hex)
+    if type(hex) ~= "string" then return nil end
+    hex = hex:gsub("%s+", "")
+    if hex == "" then return nil end
+    if hex:sub(1, 1) ~= "#" then hex = "#" .. hex end
+    hex = hex:upper()
+    if hex:match("^#%x%x%x%x%x%x$") then return hex end
+    return nil
+end
+
+local function readHex(key)
+    if G_reader_settings and G_reader_settings.readSetting then
+        local n = normalizeHex(G_reader_settings:readSetting(SETTINGS_PREFIX .. key))
+        if n then return n end
+    end
+    return DEFAULTS[key]
+end
+
+local function saveHex(key, hex)
+    if G_reader_settings and G_reader_settings.saveSetting then
+        G_reader_settings:saveSetting(SETTINGS_PREFIX .. key, hex)
+    end
+end
+
+-- Small cache of built Blitbuffer color objects: getColor() is called a
+-- couple dozen times on every single popup rebuild, so avoid reparsing the
+-- hex string and hitting G_reader_settings that often. Invalidated
+-- whenever the relevant color changes (setHex/resetToDefault below).
+local _color_cache = {}
+
+local function buildColor(hex)
+    local ok, color = pcall(Blitbuffer.colorFromString, hex)
+    if ok and color then return color end
+    return Blitbuffer.COLOR_BLACK
+end
+
+local M = {}
+
+function M.getDefaultHex(key)
+    return DEFAULTS[key]
+end
+
+function M.getHex(key)
+    return readHex(key)
+end
+
+function M.getColor(key)
+    local hex = readHex(key)
+    local cached = _color_cache[key]
+    if cached and cached.hex == hex then
+        return cached.color
+    end
+    local color = buildColor(hex)
+    _color_cache[key] = { hex = hex, color = color }
+    return color
+end
+
+function M.setHex(key, hex)
+    local n = normalizeHex(hex)
+    if not n then return false end
+    saveHex(key, n)
+    _color_cache[key] = nil
+    return true
+end
+
+function M.resetToDefault(key)
+    saveHex(key, DEFAULTS[key])
+    _color_cache[key] = nil
+end
+
+function M.isDefault(key)
+    return readHex(key) == DEFAULTS[key]
+end
+
+-- One shorthand accessor per key - reads more naturally than
+-- Colors.getColor("active_bar") at the many call sites in both views.
+function M.activeBar()   return M.getColor("active_bar")   end
+function M.inactiveBar() return M.getColor("inactive_bar") end
+function M.trendLine()   return M.getColor("trend_line")   end
+function M.label()       return M.getColor("label")        end
+function M.value()       return M.getColor("value")        end
+function M.section()     return M.getColor("section")      end
+function M.small()       return M.getColor("small")        end
+
+-- Menu ---------------------------------------------------------------
+
+local function labelFor(key)
+    local labels = {
+        active_bar   = _("Active column color"),
+        inactive_bar = _("Inactive column color"),
+        trend_line   = _("Trend chart line color"),
+        label        = _("Label color"),
+        value        = _("Value color"),
+        section      = _("Section color"),
+        small        = _("Chart label color"),
+    }
+    return labels[key] or key
+end
+
+local function showHexInputDialog(key, touchmenu_instance, on_change)
+    local dialog
+    dialog = InputDialog:new{
+        title   = labelFor(key),
+        input   = M.getHex(key),
+        input_hint = "#RRGGBB",
+        description = _("Enter a hex color code (e.g. #1E90FF), the way KOReader expects it."),
+        buttons = {
+            {
+                {
+                    text = _("Cancel"),
+                    id   = "close",
+                    callback = function()
+                        UIManager:close(dialog)
+                    end,
+                },
+                {
+                    text = _("Default"),
+                    callback = function()
+                        M.resetToDefault(key)
+                        UIManager:close(dialog)
+                        if touchmenu_instance then touchmenu_instance:updateItems() end
+                        if on_change then on_change() end
+                    end,
+                },
+                {
+                    text = _("Save"),
+                    is_enter_default = true,
+                    callback = function()
+                        local text = dialog:getInputText()
+                        if M.setHex(key, text) then
+                            UIManager:close(dialog)
+                            if touchmenu_instance then touchmenu_instance:updateItems() end
+                            if on_change then on_change() end
+                        else
+                            UIManager:show(InfoMessage:new{
+                                text = _("Not a valid hex color code, e.g. #1E90FF."),
+                            })
+                        end
+                    end,
+                },
+            },
+        },
+    }
+    UIManager:show(dialog)
+    dialog:onShowKeyboard()
+end
+
+-- Returns the sub_item_table for a "Colors" menu entry. on_change (optional)
+-- is invoked every time a color is changed or reset, so the caller can e.g.
+-- close/refresh any currently open popup. The menu itself is always kept
+-- in sync via the touchmenu_instance KOReader passes into every callback.
+function M.buildMenu(on_change)
+    local sub_item_table = {}
+    for _, key in ipairs(KEY_ORDER) do
+        table.insert(sub_item_table, {
+            text_func = function()
+                return labelFor(key) .. ": " .. M.getHex(key)
+            end,
+            keep_menu_open = true,
+            callback = function(touchmenu_instance)
+                showHexInputDialog(key, touchmenu_instance, on_change)
+            end,
+        })
+    end
+    table.insert(sub_item_table, {
+        text = _("Reset all colors to default"),
+        keep_menu_open = true,
+        separator = true,
+        callback = function(touchmenu_instance)
+            UIManager:show(ConfirmBox:new{
+                text = _("Reset all colors to their default values?"),
+                ok_text = _("Reset"),
+                ok_callback = function()
+                    for _, key in ipairs(KEY_ORDER) do
+                        M.resetToDefault(key)
+                    end
+                    if touchmenu_instance then touchmenu_instance:updateItems() end
+                    if on_change then on_change() end
+                end,
+            })
+        end,
+    })
+    return sub_item_table
+end
+
+return M

--- a/colors.lua
+++ b/colors.lua
@@ -9,6 +9,7 @@ settings driving every chart/diagram and label in the plugin:
                 month, the current chapter's read portion, the trend dot)
   inactive_bar  every other bar/point, and chart baselines
   trend_line    the connecting line in the "last 8 weeks" trend chart
+  separator     the divider lines between sections/columns in both popups
   label         "label" font role   (units/descriptions next to a value)
   value         "value" font role   (the big numbers)
   section       "section" font role (section headers, year header)
@@ -121,7 +122,7 @@ function ColorBar:paintTo(bb, x, y)
 end
 
 -- Order the "Colors" menu is built in.
-local KEY_ORDER = { "active_bar", "inactive_bar", "trend_line", "label", "value", "section", "small" }
+local KEY_ORDER = { "active_bar", "inactive_bar", "trend_line", "separator", "label", "value", "section", "small" }
 
 -- These match what was previously hard-coded directly in the two view
 -- files (Blitbuffer.COLOR_BLACK = "#000000", Blitbuffer.COLOR_GRAY = "#AAAAAA"),
@@ -131,6 +132,7 @@ local DEFAULTS = {
     active_bar   = "#000000",
     inactive_bar = "#AAAAAA",
     trend_line   = "#000000",
+    separator    = "#AAAAAA",
     label        = "#000000",
     value        = "#000000",
     section      = "#000000",
@@ -226,6 +228,7 @@ end
 function M.activeBar()   return M.getColor("active_bar")   end
 function M.inactiveBar() return M.getColor("inactive_bar") end
 function M.trendLine()   return M.getColor("trend_line")   end
+function M.separator()   return M.getColor("separator")    end
 function M.label()       return M.getColor("label")        end
 function M.value()       return M.getColor("value")        end
 function M.section()     return M.getColor("section")      end
@@ -238,6 +241,7 @@ local function labelFor(key)
         active_bar   = _("Active column color"),
         inactive_bar = _("Inactive column color"),
         trend_line   = _("Trend chart line color"),
+        separator    = _("Separator line color"),
         label        = _("Label color"),
         value        = _("Value color"),
         section      = _("Section color"),

--- a/colors.lua
+++ b/colors.lua
@@ -41,10 +41,56 @@ local Blitbuffer  = require("ffi/blitbuffer")
 local ConfirmBox  = require("ui/widget/confirmbox")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
+local LineWidget  = require("ui/widget/linewidget")
 local UIManager    = require("ui/uimanager")
 
 local L10N = ...
 local _ = L10N._
+
+-- ---------------------------------------------------------------------
+-- Custom hex colors need bb:paintRectRGB32, not bb:paintRect.
+--
+-- Blitbuffer.colorFromString("#RRGGBB") always returns a 32bit RGB color
+-- object, even for plain black/white/gray. LineWidget:paintTo (the
+-- widget used for every bar, dot and baseline in both popups) always
+-- calls bb:paintRect(), which only handles the handful of native 8bit
+-- grayscale colors (Blitbuffer.COLOR_BLACK/GRAY/WHITE/...) correctly -
+-- on an actual (typically 8bit/grayscale) e-ink framebuffer, feeding it
+-- an arbitrary RGB32 color silently misrenders (usually as black),
+-- which is why custom colors otherwise look like they "don't work".
+-- Patching paintTo to fall back to bb:paintRectRGB32() for genuinely
+-- non-8bit colors fixes this, while leaving every other LineWidget in
+-- KOReader (and our own native-color usages) untouched.
+-- Guarded so re-loading this module never wraps paintTo twice.
+if not LineWidget._reading_insights_rgb_patch then
+    local original_paintTo = LineWidget.paintTo
+
+    function LineWidget:paintTo(bb, x, y)
+        if self.style == "none" then return end
+        if not self.background or Blitbuffer.isColor8(self.background) then
+            return original_paintTo(self, bb, x, y)
+        end
+
+        local function paintRect(px, py, w, h, color)
+            bb:paintRectRGB32(px, py, w, h, color)
+        end
+
+        if self.style == "dashed" then
+            for i = 0, self.dimen.w - 20, 20 do
+                paintRect(x + i, y, 16, self.dimen.h, self.background)
+            end
+        elseif self.empty_segments then
+            paintRect(x, y, self.empty_segments[1].s, self.dimen.h, self.background)
+            paintRect(x + self.empty_segments[1].e, y,
+                self.dimen.w - self.empty_segments[1].e, self.dimen.h, self.background)
+        else
+            paintRect(x, y, self.dimen.w, self.dimen.h, self.background)
+        end
+    end
+
+    LineWidget._reading_insights_rgb_patch = true
+end
+-- ---------------------------------------------------------------------
 
 -- Order the "Colors" menu is built in.
 local KEY_ORDER = { "active_bar", "inactive_bar", "trend_line", "label", "value", "section", "small" }

--- a/colors.lua
+++ b/colors.lua
@@ -39,10 +39,12 @@ Exposes:
 
 local Blitbuffer  = require("ffi/blitbuffer")
 local ConfirmBox  = require("ui/widget/confirmbox")
+local Geom        = require("ui/geometry")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
 local LineWidget  = require("ui/widget/linewidget")
 local UIManager    = require("ui/uimanager")
+local Widget      = require("ui/widget/widget")
 
 local L10N = ...
 local _ = L10N._
@@ -91,6 +93,32 @@ if not LineWidget._reading_insights_rgb_patch then
     LineWidget._reading_insights_rgb_patch = true
 end
 -- ---------------------------------------------------------------------
+
+-- A small solid-color rectangle widget, used everywhere a bar/dot/
+-- baseline needs one of *our* user-configurable colors (active_bar,
+-- inactive_bar, ...). Deliberately independent from the LineWidget
+-- patch above (belt-and-braces): it always picks the right bb paint
+-- call itself, rather than relying on a monkey-patched shared class,
+-- so bar colors can't silently keep rendering black/gray if that patch
+-- ever fails to apply for any reason.
+local ColorBar = Widget:extend{
+    width  = nil,
+    height = nil,
+    color  = nil,
+}
+
+function ColorBar:getSize()
+    return Geom:new{ w = self.width, h = self.height }
+end
+
+function ColorBar:paintTo(bb, x, y)
+    if not self.color then return end
+    if Blitbuffer.isColor8(self.color) then
+        bb:paintRect(x, y, self.width, self.height, self.color)
+    else
+        bb:paintRectRGB32(x, y, self.width, self.height, self.color)
+    end
+end
 
 -- Order the "Colors" menu is built in.
 local KEY_ORDER = { "active_bar", "inactive_bar", "trend_line", "label", "value", "section", "small" }
@@ -166,6 +194,14 @@ function M.getColor(key)
     local color = buildColor(hex)
     _color_cache[key] = { hex = hex, color = color }
     return color
+end
+
+-- Solid-color rectangle (bar segment, baseline, trend dot, ...) that
+-- always renders the given color correctly - see the ColorBar widget
+-- above. `color` is a Blitbuffer color object, e.g. from getColor()/
+-- activeBar()/inactiveBar().
+function M.newBar(width, height, color)
+    return ColorBar:new{ width = width, height = height, color = color }
 end
 
 function M.setHex(key, hex)

--- a/insights_view.lua
+++ b/insights_view.lua
@@ -710,10 +710,7 @@ local function buildColumnSeparator(column_gap, height)
         VerticalGroup:new{
             align = "center",
             VerticalSpan:new{ height = v_padding },
-            LineWidget:new{
-                dimen = Geom:new{ w = Size.line.medium, h = height - 2 * v_padding },
-                background = Blitbuffer.COLOR_GRAY,
-            },
+            Colors.newBar(Size.line.medium, height - 2 * v_padding, Colors.separator()),
             VerticalSpan:new{ height = v_padding },
         },
         HorizontalSpan:new{ width = column_gap },
@@ -819,18 +816,14 @@ local function addSectionWithRow(sections, header_widget, row, layout, opts)
     table.insert(sections, header_widget)
     table.insert(sections, VerticalSpan:new{ height = Size.padding.default })
     if add_divider and not no_top_line then
-        table.insert(sections, padded(layout.padding_h, LineWidget:new{
-            dimen      = Geom:new{ w = layout.content_width, h = Size.line.thin },
-            background = Blitbuffer.COLOR_GRAY,
-        }))
+        table.insert(sections, padded(layout.padding_h,
+            Colors.newBar(layout.content_width, Size.line.thin, Colors.separator())))
     end
     table.insert(sections, pad_row and padded(layout.padding_h, row) or row)
     table.insert(sections, VerticalSpan:new{ height = Size.padding.large })
     if add_divider and not no_bottom_line then
-        table.insert(sections, padded(layout.padding_h, LineWidget:new{
-            dimen      = Geom:new{ w = layout.content_width, h = Size.line.thick },
-            background = Blitbuffer.COLOR_GRAY,
-        }))
+        table.insert(sections, padded(layout.padding_h,
+            Colors.newBar(layout.content_width, Size.line.thick, Colors.separator())))
     end
 end
 
@@ -1643,10 +1636,7 @@ local function showStreakDatePopup(dates, is_weekly, is_current)
         dimen = Geom:new{ w = content_width, h = date_w:getSize().h }, date_w,
     })
     table.insert(content, VerticalSpan:new{ height = Size.padding.default })
-    table.insert(content, LineWidget:new{
-        dimen      = Geom:new{ w = content_width, h = Size.line.thin },
-        background = Blitbuffer.COLOR_GRAY,
-    })
+    table.insert(content, Colors.newBar(content_width, Size.line.thin, Colors.separator()))
     table.insert(content, VerticalSpan:new{ height = Size.padding.large })
 
     local value_lines = VerticalGroup:new{ align = "left" }
@@ -3260,10 +3250,7 @@ function ReadingInsightsPopup:_buildUI()
     local content = VerticalGroup:new{
         align = "left",
         title_bar,
-        padded(layout.padding_h, LineWidget:new{
-            dimen      = Geom:new{ w = layout.content_width, h = Size.line.thick },
-            background = Blitbuffer.COLOR_GRAY,
-        }),
+        padded(layout.padding_h, Colors.newBar(layout.content_width, Size.line.thick, Colors.separator())),
         sections,
         VerticalSpan:new{ height = title_bar:getSize().h },
     }

--- a/insights_view.lua
+++ b/insights_view.lua
@@ -1066,15 +1066,9 @@ local function buildMonthlyChart(popup_self, monthly_data, layout, fonts)
             local bar_column = VerticalGroup:new{ align = "center" }
             table.insert(bar_column, centered_label)
             if bar_h > 0 then
-                table.insert(bar_column, LineWidget:new{
-                    dimen      = Geom:new{ w = bar_width, h = bar_h },
-                    background = bar_color,
-                })
+                table.insert(bar_column, Colors.newBar(bar_width, bar_h, bar_color))
             end
-            table.insert(bar_column, LineWidget:new{
-                dimen      = Geom:new{ w = bar_width, h = baseline_h },
-                background = bar_color,
-            })
+            table.insert(bar_column, Colors.newBar(bar_width, baseline_h, bar_color))
 
             local bar_container = BottomContainer:new{
                 dimen = Geom:new{ w = bar_width, h = total_bar_height },
@@ -1309,18 +1303,12 @@ local function buildLine8WeekChart(weeks, metric, chart_width, fonts)
         end
         table.insert(col_group, CenterContainer:new{
             dimen = Geom:new{ w = col_width, h = dot_size },
-            LineWidget:new{
-                dimen      = Geom:new{ w = dot_size, h = dot_size },
-                background = Colors.activeBar(),
-            },
+            Colors.newBar(dot_size, dot_size, Colors.activeBar()),
         })
         if dot_y_from_bottom > 0 then
             table.insert(col_group, VerticalSpan:new{ height = dot_y_from_bottom })
         end
-        table.insert(col_group, LineWidget:new{
-            dimen      = Geom:new{ w = col_width, h = baseline_h },
-            background = Colors.inactiveBar(),
-        })
+        table.insert(col_group, Colors.newBar(col_width, baseline_h, Colors.inactiveBar()))
 
         table.insert(bars_row, BottomContainer:new{
             dimen = Geom:new{ w = col_width, h = total_col_h },
@@ -1466,15 +1454,9 @@ local function buildWeeklyChart(popup_self, daily_data, layout, fonts)
         local bar_column = VerticalGroup:new{ align = "center" }
         table.insert(bar_column, centered_label)
         if bar_h > 0 then
-            table.insert(bar_column, LineWidget:new{
-                dimen      = Geom:new{ w = bar_width, h = bar_h },
-                background = bar_color,
-            })
+            table.insert(bar_column, Colors.newBar(bar_width, bar_h, bar_color))
         end
-        table.insert(bar_column, LineWidget:new{
-            dimen      = Geom:new{ w = bar_width, h = baseline_h },
-            background = bar_color,
-        })
+        table.insert(bar_column, Colors.newBar(bar_width, baseline_h, bar_color))
 
         local bar_container = BottomContainer:new{
             dimen = Geom:new{ w = bar_width, h = total_bar_height },

--- a/insights_view.lua
+++ b/insights_view.lua
@@ -95,10 +95,10 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local Screen = Device.screen
 local T = require("ffi/util").template
 
--- Shared translations/number-formatting, loaded once by main.lua and passed
--- in as the module argument (see the `return function(L10N) ... end` wrapper
--- at the bottom of this file).
-local L10N = ...
+-- Shared translations/number-formatting, and shared chart/text color
+-- settings, both loaded once by main.lua and passed in as this chunk's
+-- arguments (see main.lua's loadModule() call for this file).
+local L10N, Colors = ...
 
 -- true: cache DB results (streaks/year_range per day, last-week per minute, yearly/monthly per day).
 -- false: always query DB fresh on open.
@@ -722,7 +722,7 @@ end
 
 local function buildSectionHeader(font_section, text, width, left_padding)
     left_padding = left_padding or Size.padding.large
-    local text_widget = TextWidget:new{ text = text, face = font_section }
+    local text_widget = TextWidget:new{ text = text, face = font_section, fgcolor = Colors.section() }
     return FrameContainer:new{
         background    = Blitbuffer.COLOR_WHITE,
         bordersize    = 0,
@@ -743,12 +743,13 @@ local function buildValueLine(font_value, font_label, col_width, value, unit)
         return TextBoxWidget:new{
             text      = unit,
             face      = font_label,
+            fgcolor   = Colors.label(),
             width     = col_width,
             alignment = "left",
         }
     end
 
-    local value_widget = TextWidget:new{ text = value, face = font_value }
+    local value_widget = TextWidget:new{ text = value, face = font_value, fgcolor = Colors.value() }
     local value_width = value_widget:getSize().w
     local text_desc_width = col_width - value_width - Size.padding.large
     return HorizontalGroup:new{
@@ -758,6 +759,7 @@ local function buildValueLine(font_value, font_label, col_width, value, unit)
         TextBoxWidget:new{
             text      = unit,
             face      = font_label,
+            fgcolor   = Colors.label(),
             width     = text_desc_width,
             alignment = "left",
         },
@@ -852,6 +854,7 @@ local function buildYearHeader(font_section, layout, year_range, selected_year)
     local year_label = TextWidget:new{
         text = tostring(selected_year),
         face = font_section,
+        fgcolor = Colors.section(),
     }
 
     local function makeSlot(yr, arrow_glyph, left, visible)
@@ -862,12 +865,12 @@ local function buildYearHeader(font_section, layout, year_range, selected_year)
         local arrow_tw = TextWidget:new{
             text    = arrow_glyph,
             face    = font_section,
-            fgcolor = Blitbuffer.COLOR_BLACK,
+            fgcolor = Colors.section(),
         }
         local yr_tw = TextWidget:new{
             text    = tostring(yr),
             face    = font_section,
-            fgcolor = Blitbuffer.COLOR_BLACK,
+            fgcolor = Colors.section(),
         }
 
         local parts
@@ -1043,7 +1046,7 @@ local function buildMonthlyChart(popup_self, monthly_data, layout, fonts)
             if bar_h == 0 and value > 0 then bar_h = 1 end
 
             local is_current = (popup_self.selected_year == current_year) and (m.month == current_month)
-            local bar_color  = is_current and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_GRAY
+            local bar_color  = is_current and Colors.activeBar() or Colors.inactiveBar()
 
             local bar_label_str
             if popup_self.mode == INSIGHTS_MODE_HOURS then
@@ -1054,7 +1057,7 @@ local function buildMonthlyChart(popup_self, monthly_data, layout, fonts)
                 bar_label_str = string.format("%02d:%02d", mo_h, mo_m)
             else
                 bar_label_str = formatNumber(value)
-            end            local value_label   = TextWidget:new{ text = bar_label_str, face = font_small }
+            end            local value_label   = TextWidget:new{ text = bar_label_str, face = font_small, fgcolor = Colors.small() }
             local centered_label = CenterContainer:new{
                 dimen  = Geom:new{ w = bar_width, h = label_height },
                 value_label,
@@ -1097,7 +1100,7 @@ local function buildMonthlyChart(popup_self, monthly_data, layout, fonts)
 
             table.insert(bars_row, tappable_bar)
 
-            local month_label_widget = TextWidget:new{ text = m.label, face = font_small }
+            local month_label_widget = TextWidget:new{ text = m.label, face = font_small, fgcolor = Colors.small() }
             table.insert(month_labels_row, CenterContainer:new{
                 dimen = Geom:new{ w = bar_width, h = month_label_widget:getSize().h },
                 month_label_widget,
@@ -1157,7 +1160,7 @@ end
 
 function LineChartWidget:paintTo(bb, x, y)
     if not self.points or #self.points == 0 then return end
-    local color = self.line_color or Blitbuffer.COLOR_BLACK
+    local color = self.line_color or Colors.trendLine()
 
     if #self.points > 1 then
         for i = 1, #self.points - 1 do
@@ -1288,7 +1291,7 @@ local function buildLine8WeekChart(weeks, metric, chart_width, fonts)
         local dot_y_from_bottom = math.floor(ratio * (bar_height - dot_size))
         local val_str = formatWeekValue(metric, weeks[i])
 
-        local value_label    = TextWidget:new{ text = val_str, face = font_small }
+        local value_label    = TextWidget:new{ text = val_str, face = font_small, fgcolor = Colors.small() }
         local centered_label = CenterContainer:new{
             dimen = Geom:new{ w = col_width, h = label_height },
             value_label,
@@ -1304,7 +1307,7 @@ local function buildLine8WeekChart(weeks, metric, chart_width, fonts)
             dimen = Geom:new{ w = col_width, h = dot_size },
             LineWidget:new{
                 dimen      = Geom:new{ w = dot_size, h = dot_size },
-                background = Blitbuffer.COLOR_BLACK,
+                background = Colors.activeBar(),
             },
         })
         if dot_y_from_bottom > 0 then
@@ -1312,7 +1315,7 @@ local function buildLine8WeekChart(weeks, metric, chart_width, fonts)
         end
         table.insert(col_group, LineWidget:new{
             dimen      = Geom:new{ w = col_width, h = baseline_h },
-            background = Blitbuffer.COLOR_GRAY,
+            background = Colors.inactiveBar(),
         })
 
         table.insert(bars_row, BottomContainer:new{
@@ -1330,7 +1333,7 @@ local function buildLine8WeekChart(weeks, metric, chart_width, fonts)
         width      = num_points * col_width,
         height     = total_col_h,
         points     = points,
-        line_color = Blitbuffer.COLOR_BLACK,
+        line_color = Colors.trendLine(),
     }
 
     local chart_area = OverlapGroup:new{
@@ -1344,7 +1347,7 @@ local function buildLine8WeekChart(weeks, metric, chart_width, fonts)
     local date_labels_row = HorizontalGroup:new{ align = "top" }
     for col = 1, num_points do
         local i = ascending and col or (num_points - col + 1)
-        local start_lbl = TextWidget:new{ text = formatShortDate(weeks[i].start_date), face = font_small }
+        local start_lbl = TextWidget:new{ text = formatShortDate(weeks[i].start_date), face = font_small, fgcolor = Colors.small() }
         local col_dates  = CenterContainer:new{
             dimen = Geom:new{ w = col_width, h = start_lbl:getSize().h },
             start_lbl,
@@ -1443,14 +1446,14 @@ local function buildWeeklyChart(popup_self, daily_data, layout, fonts)
         local bar_h = math.floor(ratio * bar_height + 0.5)
         if bar_h == 0 and value > 0 then bar_h = 1 end
 
-        local bar_color = (WEEKLY_CHART_HIGHLIGHT_TODAY and i == 1) and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_GRAY
+        local bar_color = (WEEKLY_CHART_HIGHLIGHT_TODAY and i == 1) and Colors.activeBar() or Colors.inactiveBar()
 
         local secs = tonumber(d.seconds) or 0
         local total_mins = math.floor(secs / 60 + 0.5)
         local h = math.floor(total_mins / 60)
         local m = total_mins % 60
         local val_str = string.format("%02d:%02d", h, m)
-        local value_label   = TextWidget:new{ text = val_str, face = font_small }
+        local value_label   = TextWidget:new{ text = val_str, face = font_small, fgcolor = Colors.small() }
         local centered_label = CenterContainer:new{
             dimen  = Geom:new{ w = bar_width, h = label_height },
             value_label,
@@ -1491,7 +1494,7 @@ local function buildWeeklyChart(popup_self, daily_data, layout, fonts)
             table.insert(bars_row, bar_container)
         end
 
-        local day_label_widget = TextWidget:new{ text = d.label, face = font_small }
+        local day_label_widget = TextWidget:new{ text = d.label, face = font_small, fgcolor = Colors.small() }
         table.insert(day_labels_row, CenterContainer:new{
             dimen = Geom:new{ w = bar_width, h = day_label_widget:getSize().h },
             day_label_widget,
@@ -1616,9 +1619,9 @@ local function showStreakDatePopup(dates, is_weekly, is_current)
     local title_w
     if is_current ~= nil then
         local label = is_current and _("Current streak") or _("Best streak")
-        title_w = TextWidget:new{ text = label, face = fonts.section }
+        title_w = TextWidget:new{ text = label, face = fonts.section, fgcolor = Colors.section() }
     end
-    local date_w = TextWidget:new{ text = start_str .. " – " .. end_str, face = fonts.label }
+    local date_w = TextWidget:new{ text = start_str .. " – " .. end_str, face = fonts.label, fgcolor = Colors.label() }
 
     -- Measure each value/label row at its own natural (unwrapped) width.
     local function naturalRowWidth(value, unit)
@@ -2669,12 +2672,12 @@ function ReadingInsightsPopup:showWeeklyTrendPopup(metric)
     local box_width   = math.floor(Screen:getWidth() * 0.86)
     local chart_width = box_width - 2 * inner_padding
 
-    local title_w = TextWidget:new{ text = trendTitle(metric), face = fonts.section }
+    local title_w = TextWidget:new{ text = trendTitle(metric), face = fonts.section, fgcolor = Colors.section() }
     local title_centered = CenterContainer:new{
         dimen = Geom:new{ w = chart_width, h = title_w:getSize().h }, title_w,
     }
 
-    local value_w = TextWidget:new{ text = totalForMetric(metric, weeks), face = fonts.value }
+    local value_w = TextWidget:new{ text = totalForMetric(metric, weeks), face = fonts.value, fgcolor = Colors.value() }
     local value_centered = CenterContainer:new{
         dimen = Geom:new{ w = chart_width, h = value_w:getSize().h }, value_w,
     }
@@ -3231,6 +3234,7 @@ function ReadingInsightsPopup:_buildUI()
                     TextWidget:new{
                         text = _("Loading data…"),
                         face = fonts.label,
+                        fgcolor = Colors.label(),
                     },
                 },
             },

--- a/insights_view.lua
+++ b/insights_view.lua
@@ -1161,6 +1161,10 @@ end
 function LineChartWidget:paintTo(bb, x, y)
     if not self.points or #self.points == 0 then return end
     local color = self.line_color or Colors.trendLine()
+    -- See colors.lua's LineWidget patch: bb:paintRect only renders native
+    -- 8bit grayscale colors correctly; arbitrary hex colors need
+    -- bb:paintRectRGB32 or they silently misrender (usually as black).
+    local paint = Blitbuffer.isColor8(color) and bb.paintRect or bb.paintRectRGB32
 
     if #self.points > 1 then
         for i = 1, #self.points - 1 do
@@ -1171,7 +1175,7 @@ function LineChartWidget:paintTo(bb, x, y)
                 local t  = s / steps
                 local px = math.floor(p1.x + dx * t + 0.5)
                 local py = math.floor(p1.y + dy * t + 0.5)
-                bb:paintRect(x + px, y + py, 2, 2, color)
+                paint(bb, x + px, y + py, 2, 2, color)
             end
         end
     end

--- a/l10n/en.po
+++ b/l10n/en.po
@@ -407,3 +407,51 @@ msgstr "day since started"
 
 msgid "days since started"
 msgstr "days since started"
+
+msgid "Colors"
+msgstr "Colors"
+
+msgid "Active column color"
+msgstr "Active column color"
+
+msgid "Inactive column color"
+msgstr "Inactive column color"
+
+msgid "Trend chart line color"
+msgstr "Trend chart line color"
+
+msgid "Label color"
+msgstr "Label color"
+
+msgid "Value color"
+msgstr "Value color"
+
+msgid "Section color"
+msgstr "Section color"
+
+msgid "Chart label color"
+msgstr "Chart label color"
+
+msgid "Reset all colors to default"
+msgstr "Reset all colors to default"
+
+msgid "Cancel"
+msgstr "Cancel"
+
+msgid "Default"
+msgstr "Default"
+
+msgid "Save"
+msgstr "Save"
+
+msgid "Enter a hex color code (e.g. #1E90FF), the way KOReader expects it."
+msgstr "Enter a hex color code (e.g. #1E90FF), the way KOReader expects it."
+
+msgid "Not a valid hex color code, e.g. #1E90FF."
+msgstr "Not a valid hex color code, e.g. #1E90FF."
+
+msgid "Reset all colors to their default values?"
+msgstr "Reset all colors to their default values?"
+
+msgid "Reset"
+msgstr "Reset"

--- a/l10n/en.po
+++ b/l10n/en.po
@@ -420,6 +420,9 @@ msgstr "Inactive column color"
 msgid "Trend chart line color"
 msgstr "Trend chart line color"
 
+msgid "Separator line color"
+msgstr "Separator line color"
+
 msgid "Label color"
 msgstr "Label color"
 

--- a/l10n/en.po
+++ b/l10n/en.po
@@ -432,6 +432,9 @@ msgstr "Section color"
 msgid "Chart label color"
 msgstr "Chart label color"
 
+msgid "Settings"
+msgstr "Settings"
+
 msgid "Reset all colors to default"
 msgstr "Reset all colors to default"
 

--- a/l10n/hu.po
+++ b/l10n/hu.po
@@ -438,6 +438,9 @@ msgstr "Szekció színe"
 msgid "Chart label color"
 msgstr "Diagram felirat színe"
 
+msgid "Settings"
+msgstr "Beállítások"
+
 msgid "Reset all colors to default"
 msgstr "Összes szín visszaállítása alapértelmezettre"
 

--- a/l10n/hu.po
+++ b/l10n/hu.po
@@ -413,3 +413,51 @@ msgstr "nappal ezelőtt elkezdve"
 
 msgid "days since started"
 msgstr "nappal ezelőtt elkezdve"
+
+msgid "Colors"
+msgstr "Színek"
+
+msgid "Active column color"
+msgstr "Aktív oszlop színe"
+
+msgid "Inactive column color"
+msgstr "Inaktív oszlop színe"
+
+msgid "Trend chart line color"
+msgstr "Trend diagram vonalának színe"
+
+msgid "Label color"
+msgstr "Fejlécek színe"
+
+msgid "Value color"
+msgstr "Értékek színe"
+
+msgid "Section color"
+msgstr "Szekció színe"
+
+msgid "Chart label color"
+msgstr "Diagram felirat színe"
+
+msgid "Reset all colors to default"
+msgstr "Összes szín visszaállítása alapértelmezettre"
+
+msgid "Cancel"
+msgstr "Mégse"
+
+msgid "Default"
+msgstr "Alapértelmezett"
+
+msgid "Save"
+msgstr "Mentés"
+
+msgid "Enter a hex color code (e.g. #1E90FF), the way KOReader expects it."
+msgstr "Add meg a szín hex kódját (pl. #1E90FF), ahogy a KOReader is kezeli."
+
+msgid "Not a valid hex color code, e.g. #1E90FF."
+msgstr "Ez nem érvényes hex színkód, pl. #1E90FF."
+
+msgid "Reset all colors to their default values?"
+msgstr "Biztosan visszaállítod az összes színt az alapértelmezettre?"
+
+msgid "Reset"
+msgstr "Visszaállítás"

--- a/l10n/hu.po
+++ b/l10n/hu.po
@@ -426,8 +426,11 @@ msgstr "Inaktív oszlop színe"
 msgid "Trend chart line color"
 msgstr "Trend diagram vonalának színe"
 
+msgid "Separator line color"
+msgstr "Elválasztó vonal színe"
+
 msgid "Label color"
-msgstr "Feliratok színe"
+msgstr "Fejlécek színe"
 
 msgid "Value color"
 msgstr "Értékek színe"

--- a/l10n/hu.po
+++ b/l10n/hu.po
@@ -427,7 +427,7 @@ msgid "Trend chart line color"
 msgstr "Trend diagram vonalának színe"
 
 msgid "Label color"
-msgstr "Fejlécek színe"
+msgstr "Feliratok színe"
 
 msgid "Value color"
 msgstr "Értékek színe"

--- a/main.lua
+++ b/main.lua
@@ -144,7 +144,8 @@ end
 
 -- Adds "Reading insights" under Tools as a submenu.
 -- Sub-entries: open the insights popup, open the stats popup (book view
--- only), plus two persistent settings for the insights popup.
+-- only), a separator, then a "Settings" submenu holding the two
+-- persistent settings for the insights popup plus the Colors submenu.
 function ReadingInsights:addToMainMenu(menu_items)
     local sub_item_table = {
         {
@@ -156,7 +157,8 @@ function ReadingInsights:addToMainMenu(menu_items)
         },
     }
 
-    if self:_hasOpenDocument() then
+    local has_open_document = self:_hasOpenDocument()
+    if has_open_document then
         table.insert(sub_item_table, {
             text = _("Show Book progress"),
             keep_menu_open = false,
@@ -166,7 +168,13 @@ function ReadingInsights:addToMainMenu(menu_items)
         })
     end
 
-    table.insert(sub_item_table, {
+    -- Separator after the two "open a popup" entries, before the
+    -- settings submenu below.
+    sub_item_table[#sub_item_table].separator = true
+
+    local settings_sub_item_table = {}
+
+    table.insert(settings_sub_item_table, {
         text = _("Full-screen refresh on open/close"),
         keep_menu_open = true,
         checked_func = function()
@@ -177,7 +185,7 @@ function ReadingInsights:addToMainMenu(menu_items)
         end,
     })
 
-    table.insert(sub_item_table, {
+    table.insert(settings_sub_item_table, {
         text_func = function()
             local order = Insights.readAscendingSetting()
                 and _("Oldest first")
@@ -214,10 +222,16 @@ function ReadingInsights:addToMainMenu(menu_items)
     -- Unified color settings for every chart/diagram and label in both
     -- popups (insights and stats). Any change here applies to both, next
     -- time each popup is (re)opened.
-    table.insert(sub_item_table, {
+    table.insert(settings_sub_item_table, {
         text = _("Colors"),
         keep_menu_open = true,
         sub_item_table = Colors.buildMenu(),
+    })
+
+    table.insert(sub_item_table, {
+        text = _("Settings"),
+        keep_menu_open = true,
+        sub_item_table = settings_sub_item_table,
     })
 
     menu_items.reading_insights_popup = {

--- a/main.lua
+++ b/main.lua
@@ -52,8 +52,12 @@ end
 local L10N = loadModule("l10n.lua")
 local _ = L10N._
 
-local Insights = loadModule("insights_view.lua", L10N)
-local StatsPopup = loadModule("stats_view.lua", L10N)
+-- Shared chart/text color settings (Colors menu), used by both views so
+-- there's a single, unified place to configure them. See colors.lua.
+local Colors = loadModule("colors.lua", L10N)
+
+local Insights = loadModule("insights_view.lua", L10N, Colors)
+local StatsPopup = loadModule("stats_view.lua", L10N, Colors)
 
 --[[
 Plugin wiring.
@@ -205,6 +209,15 @@ function ReadingInsights:addToMainMenu(menu_items)
                 end,
             },
         },
+    })
+
+    -- Unified color settings for every chart/diagram and label in both
+    -- popups (insights and stats). Any change here applies to both, next
+    -- time each popup is (re)opened.
+    table.insert(sub_item_table, {
+        text = _("Colors"),
+        keep_menu_open = true,
+        sub_item_table = Colors.buildMenu(),
     })
 
     menu_items.reading_insights_popup = {

--- a/stats_view.lua
+++ b/stats_view.lua
@@ -441,10 +441,7 @@ local function buildColumnSeparator(column_gap, height)
         VerticalGroup:new{
             align = "center",
             VerticalSpan:new{ height = v_padding },
-            LineWidget:new{
-                dimen      = Geom:new{ w = Size.line.medium, h = height - 2 * v_padding },
-                background = Blitbuffer.COLOR_GRAY,
-            },
+            Colors.newBar(Size.line.medium, height - 2 * v_padding, Colors.separator()),
             VerticalSpan:new{ height = v_padding },
         },
         HorizontalSpan:new{ width = column_gap },
@@ -567,10 +564,8 @@ end
 local function addSectionWithRow(sections, header_widget, row, layout)
     table.insert(sections, header_widget)
     table.insert(sections, VerticalSpan:new{ height = Size.padding.default })
-    table.insert(sections, padded(layout.padding_h, LineWidget:new{
-        dimen      = Geom:new{ w = layout.full_width - 2 * layout.padding_h, h = Size.line.thin },
-        background = Blitbuffer.COLOR_GRAY,
-    }))
+    table.insert(sections, padded(layout.padding_h,
+        Colors.newBar(layout.full_width - 2 * layout.padding_h, Size.line.thin, Colors.separator())))
     table.insert(sections, padded(layout.padding_h, row))
     table.insert(sections, VerticalSpan:new{ height = Size.padding.large })
 end
@@ -771,10 +766,8 @@ local function buildSections(stats, fonts, layout, popup)
             popup:_rebuildUI()
         end or nil
     )
-    table.insert(sections, padded(layout.padding_h, LineWidget:new{
-        dimen      = Geom:new{ w = layout.full_width - 2 * layout.padding_h, h = Size.line.thick },
-        background = Blitbuffer.COLOR_GRAY,
-    }))
+    table.insert(sections, padded(layout.padding_h,
+        Colors.newBar(layout.full_width - 2 * layout.padding_h, Size.line.thick, Colors.separator())))
     local this_book_header = buildSectionHeader(fonts.section, _("This book"), layout.full_width)
     if popup then
         popup._this_book_header = this_book_header
@@ -794,22 +787,16 @@ local function buildSections(stats, fonts, layout, popup)
 
     if chapter_bar then
         if popup then popup._chapter_bar = chapter_bar end
-            table.insert(sections, padded(layout.padding_h, LineWidget:new{
-                dimen      = Geom:new{ w = layout.full_width - 2 * layout.padding_h, h = Size.line.thin },
-                background = Blitbuffer.COLOR_GRAY,
-            }))
+            table.insert(sections, padded(layout.padding_h,
+                Colors.newBar(layout.full_width - 2 * layout.padding_h, Size.line.thin, Colors.separator())))
         table.insert(sections, chapter_bar)
     end
-    table.insert(sections, padded(layout.padding_h, LineWidget:new{
-        dimen      = Geom:new{ w = layout.full_width - 2 * layout.padding_h, h = Size.line.thick },
-        background = Blitbuffer.COLOR_GRAY,
-    }))
+    table.insert(sections, padded(layout.padding_h,
+        Colors.newBar(layout.full_width - 2 * layout.padding_h, Size.line.thick, Colors.separator())))
     table.insert(sections, buildSectionHeader(fonts.section, _("Pace"), layout.full_width))
     table.insert(sections, VerticalSpan:new{ height = Size.padding.default })
-    table.insert(sections, padded(layout.padding_h, LineWidget:new{
-        dimen      = Geom:new{ w = layout.full_width - 2 * layout.padding_h, h = Size.line.thin },
-        background = Blitbuffer.COLOR_GRAY,
-    }))
+    table.insert(sections, padded(layout.padding_h,
+        Colors.newBar(layout.full_width - 2 * layout.padding_h, Size.line.thin, Colors.separator())))
     table.insert(sections, padded(layout.padding_h, pace_row))
 
     -- Last row: "started N days ago" | "N days of reading left".

--- a/stats_view.lua
+++ b/stats_view.lua
@@ -47,9 +47,10 @@ local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local Screen = Device.screen
 
--- Shared translations/number-formatting, passed in as the module argument
--- by main.lua (see the header comment above).
-local L10N = ...
+-- Shared translations/number-formatting, and shared chart/text color
+-- settings, both passed in as this chunk's arguments by main.lua (see the
+-- header comment above).
+local L10N, Colors = ...
 local _            = L10N._
 local N_           = L10N.N_
 local getLangBase  = L10N.getLangBase
@@ -453,7 +454,7 @@ end
 -- No radius, left-aligned text with padding_left; width comes from parent.
 local function buildSectionHeader(font_section, text, width, left_padding)
     left_padding = left_padding or Size.padding.large
-    local text_widget = TextWidget:new{ text = text, face = font_section }
+    local text_widget = TextWidget:new{ text = text, face = font_section, fgcolor = Colors.section() }
     return FrameContainer:new{
         background     = Blitbuffer.COLOR_WHITE,
         bordersize     = 0,
@@ -473,6 +474,7 @@ local function buildValueLine(font_value, font_label, col_width, time_data, labe
         return TextBoxWidget:new{
             text      = time_data.unit,
             face      = font_label,
+            fgcolor   = Colors.label(),
             width     = col_width,
             alignment = "left",
         }
@@ -486,7 +488,7 @@ local function buildValueLine(font_value, font_label, col_width, time_data, labe
             desc = label
         end
     end
-    local value_widget    = TextWidget:new{ text = time_data.value, face = font_value }
+    local value_widget    = TextWidget:new{ text = time_data.value, face = font_value, fgcolor = Colors.value() }
     local value_width     = value_widget:getSize().w
     local text_desc_width = col_width - value_width - Size.padding.large
     if text_desc_width <= 0 then
@@ -496,6 +498,7 @@ local function buildValueLine(font_value, font_label, col_width, time_data, labe
             TextBoxWidget:new{
                 text      = desc,
                 face      = font_label,
+                fgcolor   = Colors.label(),
                 width     = col_width,
                 alignment = "left",
             },
@@ -508,6 +511,7 @@ local function buildValueLine(font_value, font_label, col_width, time_data, labe
         TextBoxWidget:new{
             text      = desc,
             face      = font_label,
+            fgcolor   = Colors.label(),
             width     = text_desc_width,
             alignment = "left",
         },
@@ -641,11 +645,11 @@ local function buildChapterBar(chapter_info, full_width, padding_h, offset_overr
                     VerticalSpan:new{ height = col_h_max - bh },
                     unread_h > 0 and LineWidget:new{
                         dimen      = Geom:new{ w = bar_w, h = unread_h },
-                        background = Blitbuffer.COLOR_GRAY_D,
+                        background = Colors.inactiveBar(),
                     } or VerticalSpan:new{ height = 0 },
                     read_h > 0 and LineWidget:new{
                         dimen      = Geom:new{ w = bar_w, h = read_h },
-                        background = Blitbuffer.COLOR_BLACK,
+                        background = Colors.activeBar(),
                     } or VerticalSpan:new{ height = 0 },
                 })
             else
@@ -654,7 +658,7 @@ local function buildChapterBar(chapter_info, full_width, padding_h, offset_overr
                     VerticalSpan:new{ height = col_h_max - bh },
                     LineWidget:new{
                         dimen      = Geom:new{ w = bar_w, h = bh },
-                        background = ch_idx < current and Blitbuffer.COLOR_BLACK or Blitbuffer.COLOR_GRAY_D,
+                        background = ch_idx < current and Colors.activeBar() or Colors.inactiveBar(),
                     },
                 })
             end

--- a/stats_view.lua
+++ b/stats_view.lua
@@ -643,23 +643,16 @@ local function buildChapterBar(chapter_info, full_width, padding_h, offset_overr
                 table.insert(bar_row, VerticalGroup:new{
                     align = "left",
                     VerticalSpan:new{ height = col_h_max - bh },
-                    unread_h > 0 and LineWidget:new{
-                        dimen      = Geom:new{ w = bar_w, h = unread_h },
-                        background = Colors.inactiveBar(),
-                    } or VerticalSpan:new{ height = 0 },
-                    read_h > 0 and LineWidget:new{
-                        dimen      = Geom:new{ w = bar_w, h = read_h },
-                        background = Colors.activeBar(),
-                    } or VerticalSpan:new{ height = 0 },
+                    unread_h > 0 and Colors.newBar(bar_w, unread_h, Colors.inactiveBar())
+                        or VerticalSpan:new{ height = 0 },
+                    read_h > 0 and Colors.newBar(bar_w, read_h, Colors.activeBar())
+                        or VerticalSpan:new{ height = 0 },
                 })
             else
                 table.insert(bar_row, VerticalGroup:new{
                     align = "left",
                     VerticalSpan:new{ height = col_h_max - bh },
-                    LineWidget:new{
-                        dimen      = Geom:new{ w = bar_w, h = bh },
-                        background = ch_idx < current and Colors.activeBar() or Colors.inactiveBar(),
-                    },
+                    Colors.newBar(bar_w, bh, ch_idx < current and Colors.activeBar() or Colors.inactiveBar()),
                 })
             end
         else


### PR DESCRIPTION
New: Colors menu (Tools → Reading insights → Settings → Colors) and what each setting controls:

Active column color (default black #000000) — the "current" bar/point in any chart: today's bar in the weekly chart, the current month's bar in the monthly chart, the current chapter's read portion in the Book progress chapter bar, and the dot marker for the current week in the 8-week trend popup.
Inactive column color (default gray #AAAAAA) — every other bar/point, plus chart baselines: all non-current bars in the weekly/monthly charts, past/future chapters in the chapter progress bar, and the trend chart's baseline.
Trend chart line color (default black #000000) — the connecting line in the "last 8 weeks" trend popup (the line itself, separate from the dot markers, which use Active/Inactive column color).
Separator line color (default gray #AAAAAA) — all the divider lines in both popups: the column separator between "Last week" and "Streaks," the thin/thick lines between sections, the line under the date in the trend popup, the line under the title bar, and the lines around the chapter bar and Pace section in Book progress.
Label color (default black) — the "label" font role: units/descriptions next to a value.
Value color (default black) — the "value" font role: the big numbers.
Section color (default black) — the "section" font role: section headers, the year header.
Chart label color (default black) — the "small" font role: chart axis/value labels and other small print.

Each entry can be set to any #RRGGBB hex color, reset individually back to its default, or all reset at once via "Reset all colors to default" at the bottom of the menu.