### PR TITLE
In-app updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,30 @@ instead of a generic cover or logo.
   full-screen refresh happens, instead of the stock screensaver painting
   first and then immediately getting replaced.
 
+## Updates
+
+*Tools → Reading insights → Updates* checks GitHub for new releases and can
+install them directly on the device — no computer/SSH needed:
+
+- **Notify on wake when update available** — opt-in silent background check
+  (at most once an hour), fired at startup and on every wake from sleep;
+  shows a small notification when a newer release is found.
+- The main **Installed version** / **Update available** row shows the
+  currently installed version and, when applicable, the version it would
+  update to; tapping it fetches the release notes for every release newer
+  than what's installed and offers **Update and restart**.
+- **Developer updates** — a pocket for testing pre-release code:
+  - **Development branch** — point the updater at a specific branch instead
+    of the latest stable release; the update row above then installs that
+    branch's current tip.
+  - **Reset to latest stable release** — clears the development branch and
+    reinstalls the latest non-prerelease release.
+
+Behind the scenes this downloads the release/branch zip from
+[peterboda236/readinginsights.koplugin](https://github.com/peterboda236/readinginsights.koplugin),
+unpacks it over the installed plugin folder, and prompts to restart
+KOReader to load the new code.
+
 ## Install
 
 1. Unpack the latest zip and copy the `readinginsights.koplugin` folder into
@@ -74,6 +98,9 @@ instead of a generic cover or logo.
    `2-reading-stats-popup.lua` in your `patches/` folder, **remove them** —
    running the patches alongside this plugin will double-register the same
    dispatcher actions.
+
+Once installed, future updates can be installed in-app — see
+[Updates](#updates) above.
 
 ## Where it shows up
 
@@ -99,6 +126,9 @@ instead of a generic cover or logo.
     pick-from-list menu of every font file KOReader/you have installed,
     or type a custom font name/alias manually; each role can be reset to
     its bundled default individually or all at once.
+  - **Updates** — check for and install new releases (or dev-branch
+    builds) straight from GitHub, no computer needed (see
+    [Updates](#updates) above).
 - **Gestures/shortcuts:** both popups are registered with `Dispatcher`, so
   they can be assigned under *Settings → Taps and gestures*:
   - `reading_insights_popup` — available everywhere (general action).
@@ -119,6 +149,8 @@ instead of a generic cover or logo.
   name and size.
 - `insights_view.lua` — the full-screen "Reading insights" popup.
 - `stats_view.lua` — the compact "Reading statistics: overview" popup.
+- `updater.lua` — the in-app updater (the "Updates" submenu): checks
+  GitHub for new releases/branches and installs them on the device.
 
 ## Translations
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -12,5 +12,5 @@ return {
     -- Bumped by the in-app updater (updater.lua) as new versions are
     -- installed. Keep in sync with the GitHub release tag (without the
     -- leading "v") each time a new release is cut.
-    version = "3.0.2",
+    version = "3.1.0",
 }

--- a/_meta.lua
+++ b/_meta.lua
@@ -1,7 +1,16 @@
 local _ = require("gettext")
 
 return {
+    -- KEEP `name`: some KOReader releases load a DISABLED plugin's identity
+    -- from _meta.lua rather than main.lua, and key the plugin-manager
+    -- enable/disable toggle off whatever name they find there. Without it,
+    -- re-enabling this plugin after disabling it could get stuck (see
+    -- bookshelf.koplugin's _meta.lua for the full writeup of this issue).
     name = "readinginsights",
     fullname = _("Reading insights"),
     description = _([[Two reading-stats popups built on top of statistics.sqlite3. "Reading insights": full-screen, scrollable history with last-week bar chart, streaks, yearly/monthly stats and charts, and all-time totals - available everywhere. "Reading statistics: overview": a compact live overlay for the book you're currently reading (chapter/book time left, progress, pace) - available in book view only. Adds an entry under Tools > Reading insights.]]),
+    -- Bumped by the in-app updater (updater.lua) as new versions are
+    -- installed. Keep in sync with the GitHub release tag (without the
+    -- leading "v") each time a new release is cut.
+    version = "3.0.0",
 }

--- a/_meta.lua
+++ b/_meta.lua
@@ -12,5 +12,5 @@ return {
     -- Bumped by the in-app updater (updater.lua) as new versions are
     -- installed. Keep in sync with the GitHub release tag (without the
     -- leading "v") each time a new release is cut.
-    version = "3.0.0",
+    version = "3.0.2",
 }

--- a/l10n/en.po
+++ b/l10n/en.po
@@ -586,3 +586,108 @@ msgstr "None"
 
 msgid "%d p"
 msgstr "%d p"
+
+msgid "Updates"
+msgstr "Updates"
+
+msgid "Notify on wake when update available"
+msgstr "Notify on wake when update available"
+
+msgid "Update available"
+msgstr "Update available"
+
+msgid "Installed version"
+msgstr "Installed version"
+
+msgid "Developer updates"
+msgstr "Developer updates"
+
+msgid "Development branch"
+msgstr "Development branch"
+
+msgid "Branch name (leave empty for stable)"
+msgstr "Branch name (leave empty for stable)"
+
+msgid "Check for updates"
+msgstr "Check for updates"
+
+msgid "Install branch"
+msgstr "Install branch"
+
+msgid "Reset to latest stable release"
+msgstr "Reset to latest stable release"
+
+msgid "Installed: v"
+msgstr "Installed: v"
+
+msgid "This will clear the development branch setting and install the latest stable release of Reading insights, then restart KOReader. Continue?"
+msgstr "This will clear the development branch setting and install the latest stable release of Reading insights, then restart KOReader. Continue?"
+
+msgid "Reading insights update available: v"
+msgstr "Reading insights update available: v"
+
+msgid "Open the releases page in a browser?"
+msgstr "Open the releases page in a browser?"
+
+msgid "Open"
+msgstr "Open"
+
+msgid "Checking for updates..."
+msgstr "Checking for updates..."
+
+msgid "Could not check for updates."
+msgstr "Could not check for updates."
+
+msgid "Reading insights is up to date."
+msgstr "Reading insights is up to date."
+
+msgid "Version: "
+msgstr "Version: "
+
+msgid "Update available!"
+msgstr "Update available!"
+
+msgid "Installed: "
+msgstr "Installed: "
+
+msgid "Latest: "
+msgstr "Latest: "
+
+msgid "Close"
+msgstr "Close"
+
+msgid "Update and restart"
+msgstr "Update and restart"
+
+msgid "No download available for this release."
+msgstr "No download available for this release."
+
+msgid "Downloading update..."
+msgstr "Downloading update..."
+
+msgid "Download failed."
+msgstr "Download failed."
+
+msgid "Installation failed: "
+msgstr "Installation failed: "
+
+msgid "Reading insights updated to v"
+msgstr "Reading insights updated to v"
+
+msgid "Restart KOReader now?"
+msgstr "Restart KOReader now?"
+
+msgid "Restart"
+msgstr "Restart"
+
+msgid "Could not install branch:"
+msgstr "Could not install branch:"
+
+msgid "Downloading latest release..."
+msgstr "Downloading latest release..."
+
+msgid "Could not fetch latest release."
+msgstr "Could not fetch latest release."
+
+msgid "Latest release has no downloadable zip."
+msgstr "Latest release has no downloadable zip."

--- a/l10n/hu.po
+++ b/l10n/hu.po
@@ -601,3 +601,108 @@ msgstr "Semmi"
 
 msgid "%d p"
 msgstr "%d o"
+
+msgid "Updates"
+msgstr "Frissítések"
+
+msgid "Notify on wake when update available"
+msgstr "Értesítés ébredéskor, ha van elérhető frissítés"
+
+msgid "Update available"
+msgstr "Elérhető frissítés"
+
+msgid "Installed version"
+msgstr "Telepített verzió"
+
+msgid "Developer updates"
+msgstr "Fejlesztői frissítések"
+
+msgid "Development branch"
+msgstr "Fejlesztői ág"
+
+msgid "Branch name (leave empty for stable)"
+msgstr "Ág neve (üresen hagyva a stabil verzió)"
+
+msgid "Check for updates"
+msgstr "Frissítések keresése"
+
+msgid "Install branch"
+msgstr "Ág telepítése"
+
+msgid "Reset to latest stable release"
+msgstr "Visszaállítás a legújabb stabil kiadásra"
+
+msgid "Installed: v"
+msgstr "Telepítve: v"
+
+msgid "This will clear the development branch setting and install the latest stable release of Reading insights, then restart KOReader. Continue?"
+msgstr "Ez törli a fejlesztői ág beállítást, telepíti a Reading insights legújabb stabil kiadását, majd újraindítja a KOReadert. Folytatod?"
+
+msgid "Reading insights update available: v"
+msgstr "Reading insights frissítés elérhető: v"
+
+msgid "Open the releases page in a browser?"
+msgstr "Megnyitod a kiadások oldalát böngészőben?"
+
+msgid "Open"
+msgstr "Megnyitás"
+
+msgid "Checking for updates..."
+msgstr "Frissítések keresése…"
+
+msgid "Could not check for updates."
+msgstr "Nem sikerült ellenőrizni a frissítéseket."
+
+msgid "Reading insights is up to date."
+msgstr "A Reading insights naprakész."
+
+msgid "Version: "
+msgstr "Verzió: "
+
+msgid "Update available!"
+msgstr "Elérhető frissítés!"
+
+msgid "Installed: "
+msgstr "Telepítve: "
+
+msgid "Latest: "
+msgstr "Legújabb: "
+
+msgid "Close"
+msgstr "Bezárás"
+
+msgid "Update and restart"
+msgstr "Frissítés és újraindítás"
+
+msgid "No download available for this release."
+msgstr "Ehhez a kiadáshoz nincs letölthető fájl."
+
+msgid "Downloading update..."
+msgstr "Frissítés letöltése…"
+
+msgid "Download failed."
+msgstr "A letöltés sikertelen."
+
+msgid "Installation failed: "
+msgstr "A telepítés sikertelen: "
+
+msgid "Reading insights updated to v"
+msgstr "A Reading insights frissítve erre: v"
+
+msgid "Restart KOReader now?"
+msgstr "Újraindítod most a KOReadert?"
+
+msgid "Restart"
+msgstr "Újraindítás"
+
+msgid "Could not install branch:"
+msgstr "Nem sikerült telepíteni az ágat:"
+
+msgid "Downloading latest release..."
+msgstr "Legújabb kiadás letöltése…"
+
+msgid "Could not fetch latest release."
+msgstr "Nem sikerült lekérni a legújabb kiadást."
+
+msgid "Latest release has no downloadable zip."
+msgstr "A legújabb kiadáshoz nincs letölthető zip fájl."

--- a/main.lua
+++ b/main.lua
@@ -76,6 +76,49 @@ local function saveScreensaverDelayMode(mode)
 end
 
 --[[
+Update settings (Updates menu). Mirrors bookshelf.koplugin's approach
+(bookshelf_updater.lua + Bookshelf:checkForUpdates, editDevBranch,
+resetToStableRelease, backgroundUpdateCheck): lets the user pull new
+plugin code straight from GitHub without an SSH push from a computer.
+
+  readinginsights_dev_branch          empty for stable, branch name for
+                                       the dev-branch install path
+  readinginsights_last_install_source "release" or "branch:<name>"
+  readinginsights_check_updates       boolean: silent wake-time check
+]]--
+local DEV_BRANCH_SETTING          = "readinginsights_dev_branch"
+local LAST_INSTALL_SOURCE_SETTING = "readinginsights_last_install_source"
+local CHECK_UPDATES_SETTING       = "readinginsights_check_updates"
+
+local function readDevBranch()
+    return G_reader_settings:readSetting(DEV_BRANCH_SETTING) or ""
+end
+
+local function saveDevBranch(branch)
+    G_reader_settings:saveSetting(DEV_BRANCH_SETTING, branch)
+end
+
+local function readLastInstallSource()
+    return G_reader_settings:readSetting(LAST_INSTALL_SOURCE_SETTING) or "release"
+end
+
+local function saveLastInstallSource(source)
+    G_reader_settings:saveSetting(LAST_INSTALL_SOURCE_SETTING, source)
+end
+
+local function readCheckUpdates()
+    return G_reader_settings:isTrue(CHECK_UPDATES_SETTING)
+end
+
+local function saveCheckUpdates(value)
+    if value then
+        G_reader_settings:makeTrue(CHECK_UPDATES_SETTING)
+    else
+        G_reader_settings:makeFalse(CHECK_UPDATES_SETTING)
+    end
+end
+
+--[[
 Suppressing KOReader's own built-in sleep screen for the duration of a
 single suspend, so it doesn't paint (full e-ink refresh) and then get
 immediately replaced by our own popup (another full refresh) a moment
@@ -171,6 +214,10 @@ local Fonts = loadModule("fonts.lua", L10N)
 local Insights = loadModule("insights_view.lua", L10N, Colors, Fonts)
 local StatsPopup = loadModule("stats_view.lua", L10N, Colors, Fonts)
 
+-- In-app updater (Updates menu): lets the user check for and install new
+-- releases of this plugin straight from GitHub. See updater.lua.
+local Updater = loadModule("updater.lua", L10N)
+
 --[[
 Plugin wiring.
 
@@ -258,6 +305,10 @@ function ReadingInsights:init()
 
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
+    -- Silent wake-time check also fires once at startup (opt-in via
+    -- "Notify on wake when update available"), so a newly-available update
+    -- can surface without waiting for the first suspend/resume cycle.
+    self:backgroundUpdateCheck()
     -- Force this plugin's entry to the top of the Tools menu
     -- (both in Reader view and in the File manager)
     UIManager:scheduleIn(1, function()
@@ -373,6 +424,185 @@ function ReadingInsights:onResume()
         UIManager:close(self._screensaver_widget)
         self._screensaver_widget = nil
     end
+    -- Wake-from-sleep also fires a silent background update check, mirroring
+    -- bookshelf.koplugin. Updater's own 1-hour internal cache prevents
+    -- wake-spam.
+    self:backgroundUpdateCheck()
+end
+
+-- ---------------------------------------------------------------------------
+-- Updates / dev-branch install
+-- ---------------------------------------------------------------------------
+-- Mirrors bookshelf.koplugin's update flow (lib/bookshelf_updater.lua +
+-- Bookshelf:checkForUpdates, editDevBranch, resetToStableRelease,
+-- backgroundUpdateCheck). Lets the user bring new plugin code onto the
+-- device without an SSH push from a computer - useful when away from the
+-- home network.
+
+-- Branch-aware update entry: if a dev branch is configured, install that
+-- branch's latest tip (no release needed). Otherwise hit the GitHub
+-- releases API and offer the latest stable. Both paths share the same
+-- download / unpack / restart-prompt pipeline inside Updater.install.
+function ReadingInsights:checkForUpdates()
+    local branch = readDevBranch()
+    if branch ~= "" then
+        Updater.installBranch(branch, function()
+            saveLastInstallSource("branch:" .. branch)
+        end)
+    else
+        Updater.check(function()
+            saveLastInstallSource("release")
+        end)
+    end
+end
+
+-- Open a single-line dialog to set / change / clear the dev branch.
+function ReadingInsights:editDevBranch(touchmenu_instance)
+    local InputDialog = require("ui/widget/inputdialog")
+    local dlg
+    dlg = InputDialog:new{
+        title       = _("Development branch"),
+        input       = readDevBranch(),
+        input_hint  = _("Branch name (leave empty for stable)"),
+        buttons = {{
+            {
+                text     = _("Cancel"),
+                id       = "close",
+                callback = function() UIManager:close(dlg) end,
+            },
+            {
+                text             = _("Save"),
+                is_enter_default = true,
+                callback         = function()
+                    local raw = dlg:getInputText() or ""
+                    local trimmed = raw:gsub("^%s+", ""):gsub("%s+$", "")
+                    saveDevBranch(trimmed)
+                    UIManager:close(dlg)
+                    if touchmenu_instance and touchmenu_instance.updateItems then
+                        touchmenu_instance:updateItems()
+                    end
+                end,
+            },
+        }},
+    }
+    UIManager:show(dlg)
+    dlg:onShowKeyboard()
+end
+
+-- Clear dev branch + install latest stable release. Used when escaping a
+-- broken branch back to a known-good release.
+function ReadingInsights:resetToStableRelease()
+    local ConfirmBox = require("ui/widget/confirmbox")
+    UIManager:show(ConfirmBox:new{
+        text = _("This will clear the development branch setting and install the latest stable release of Reading insights, then restart KOReader. Continue?"),
+        ok_text = _("Reset"),
+        ok_callback = function()
+            saveDevBranch("")
+            Updater.installLatestStable(function()
+                saveLastInstallSource("release")
+            end)
+        end,
+    })
+end
+
+-- Silent background poll: checks at most once an hour, only when the user
+-- has opted in via "Notify on wake when update available". Surfaces a
+-- short notification if a newer release tag is found.
+function ReadingInsights:backgroundUpdateCheck()
+    if not readCheckUpdates() then return end
+    Updater.checkBackground(function(ver)
+        local Notification = require("ui/widget/notification")
+        Notification:notify(_("Reading insights update available: v") .. ver,
+            Notification.SOURCE_ALWAYS_SHOW)
+    end)
+end
+
+-- Drill-down menu for the in-app updater: a "Notify" toggle, a primary
+-- update row that auto-relabels when an update is queued, and a
+-- "Developer updates" pocket for the dev-branch picker + reset-to-stable.
+--
+-- Reads every value fresh from G_reader_settings (via readDevBranch() /
+-- readLastInstallSource() / readCheckUpdates()) rather than caching on
+-- self: this plugin runs one instance per context (Reader and File
+-- manager, is_doc_only = false), and both build this same menu, so a
+-- self-cached value edited in one instance would go stale in the other
+-- until the next restart. Same reasoning as the screensaver-mode settings
+-- above.
+function ReadingInsights:_updateSubItems()
+    local outer = self
+    return {
+        {
+            text         = _("Notify on wake when update available"),
+            checked_func = function() return readCheckUpdates() end,
+            callback     = function()
+                saveCheckUpdates(not readCheckUpdates())
+            end,
+        },
+        {
+            text_func = function()
+                local current   = Updater.getInstalledVersion()
+                local available = Updater.getAvailableUpdate()
+                local source    = readLastInstallSource()
+                local source_suffix = ""
+                if source ~= "release" then
+                    local branch = source:match("^branch:(.+)$") or source
+                    source_suffix = " (branch: " .. branch .. ")"
+                end
+                if available then
+                    return _("Update available") .. ": v" .. current .. source_suffix
+                        .. " \xE2\x86\x92 v" .. available
+                end
+                return _("Installed version") .. ": v" .. current .. source_suffix
+            end,
+            keep_menu_open = true,
+            callback = function() outer:checkForUpdates() end,
+        },
+        {
+            text = _("Developer updates"),
+            sub_item_table = {
+                {
+                    text_func = function()
+                        local b = readDevBranch()
+                        if b == "" then return _("Development branch") end
+                        return _("Development branch") .. ": " .. b
+                    end,
+                    keep_menu_open = true,
+                    callback = function(touchmenu_instance)
+                        outer:editDevBranch(touchmenu_instance)
+                    end,
+                },
+                {
+                    text_func = function()
+                        local b = readDevBranch()
+                        if b == "" then return _("Check for updates") end
+                        return _("Install branch") .. ": " .. b
+                    end,
+                    keep_menu_open = true,
+                    callback = function() outer:checkForUpdates() end,
+                },
+                {
+                    text           = _("Reset to latest stable release"),
+                    keep_menu_open = true,
+                    callback       = function() outer:resetToStableRelease() end,
+                },
+                {
+                    -- Disabled status row: shows "Installed: vX (release)" /
+                    -- "(branch: foo)". Tap is a no-op via enabled_func=false.
+                    text_func = function()
+                        local current = Updater.getInstalledVersion()
+                        local source  = readLastInstallSource()
+                        if source == "release" then
+                            return _("Installed: v") .. current .. " (release)"
+                        end
+                        local branch = source:match("^branch:(.+)$") or source
+                        return _("Installed: v") .. current .. " (branch: " .. branch .. ")"
+                    end,
+                    enabled_func   = function() return false end,
+                    keep_menu_open = true,
+                },
+            },
+        },
+    }
 end
 
 -- A document has just finished opening (Reader view): re-sync, since
@@ -657,6 +887,14 @@ function ReadingInsights:addToMainMenu(menu_items)
         text = _("Settings"),
         keep_menu_open = true,
         sub_item_table = settings_sub_item_table,
+    })
+
+    -- In-app updater: check for / install new releases straight from
+    -- GitHub. See updater.lua and the ReadingInsights:_updateSubItems()
+    -- family of methods above.
+    table.insert(sub_item_table, {
+        text                = _("Updates"),
+        sub_item_table_func = function() return self:_updateSubItems() end,
     })
 
     menu_items.reading_insights_popup = {

--- a/updater.lua
+++ b/updater.lua
@@ -1,0 +1,499 @@
+--[[
+Reading Insights - in-app updater.
+
+Mirrors bookshelf.koplugin's lib/bookshelf_updater.lua: lets the user check
+for and install new releases of this plugin directly from GitHub, without
+having to plug the device into a computer. Also supports pulling a specific
+development branch's tip, for testing pre-release builds.
+
+Loaded by main.lua via loadfile(...)( L10N ) and handed straight in, so
+`local L10N = ...` at the top is all this module needs.
+
+Exposes:
+  getInstalledVersion()               reads version from this plugin's
+                                       _meta.lua ("unknown" if missing)
+  composeBranchUrl(branch)            GitHub zipball URL for a branch
+  getAvailableUpdate()                cached (version, zip_url) pair from
+                                       the last background/foreground check
+  checkBackground(on_update_found)    silent check, at most once an hour
+  check(on_success)                   foreground check with release-notes
+                                       viewer + "Update and restart" button
+  install(zip_url, old_version, new_version, on_success, error_label)
+                                       shared download/unpack/restart pipeline
+  installBranch(branch, on_success)   install a dev branch's latest tip
+  installLatestStable(on_success)     install the latest non-prerelease
+                                       release regardless of installed version
+  offerReleasesPage(message)          fallback: offer to open the releases
+                                       page in a browser
+]]--
+
+local ConfirmBox  = require("ui/widget/confirmbox")
+local Device      = require("device")
+local InfoMessage = require("ui/widget/infomessage")
+local UIManager   = require("ui/uimanager")
+
+local L10N = ...
+local _ = L10N._
+
+local GITHUB_REPO = "peterboda236/readinginsights.koplugin"
+local PLUGIN_ID    = "readinginsights.koplugin"
+local UA_PRODUCT   = "KOReader-ReadingInsights"
+
+local Updater = {}
+
+-- Background check state (session-only, not persisted)
+local _cached_version = nil   -- latest available version string, or nil
+local _cached_zip_url = nil   -- download URL for the latest release ZIP
+local _last_check_time = nil  -- os.time() of last successful or attempted check
+local _check_in_flight = false
+local CHECK_INTERVAL = 3600   -- 1 hour
+
+function Updater.getInstalledVersion()
+    local DataStorage = require("datastorage")
+    local meta_path = DataStorage:getDataDir() .. "/plugins/" .. PLUGIN_ID .. "/_meta.lua"
+    local ok_meta, meta = pcall(dofile, meta_path)
+    return (ok_meta and meta and meta.version) or "unknown"
+end
+
+local function parseVersion(v)
+    local parts = {}
+    for part in tostring(v):gsub("^v", ""):gmatch("([^.]+)") do
+        table.insert(parts, tonumber(part) or 0)
+    end
+    return parts
+end
+
+local function isNewer(v1, v2)
+    local a, b = parseVersion(v1), parseVersion(v2)
+    for i = 1, math.max(#a, #b) do
+        local x, y = a[i] or 0, b[i] or 0
+        if x > y then return true end
+        if x < y then return false end
+    end
+    return false
+end
+
+--- Compose the GitHub branch-archive URL for a given branch name.
+-- Branch path is URL-encoded except for alnum, dash, underscore, dot, tilde
+-- and forward slash (so feature/foo keeps its slash). Uses the public
+-- api.github.com zipball endpoint.
+function Updater.composeBranchUrl(branch)
+    local encoded = branch:gsub("[^%w%-_/.~]", function(c)
+        return string.format("%%%02X", c:byte())
+    end)
+    return string.format(
+        "https://api.github.com/repos/%s/zipball/%s",
+        GITHUB_REPO, encoded)
+end
+
+--- Try LuaSocket first, fall back to curl for platforms where SSL crashes.
+local function httpGetJSON(url, user_agent)
+    local json = require("json")
+    local ok_require, http, ltn12, socket, socketutil =
+        pcall(function()
+            return require("socket/http"),
+                   require("ltn12"),
+                   require("socket"),
+                   require("socketutil")
+        end)
+    if ok_require then
+        local body = {}
+        local ok_req, code = pcall(function()
+            socketutil:set_timeout(socketutil.LARGE_BLOCK_TIMEOUT, socketutil.LARGE_TOTAL_TIMEOUT)
+            local c = socket.skip(1, http.request({
+                url = url,
+                method = "GET",
+                headers = {
+                    ["User-Agent"] = user_agent,
+                    ["Accept"]     = "application/vnd.github.v3+json",
+                },
+                sink = ltn12.sink.table(body),
+                redirect = true,
+            }))
+            socketutil:reset_timeout()
+            return c
+        end)
+        if ok_req and code == 200 then
+            local ok, data = pcall(json.decode, table.concat(body))
+            if ok then return data end
+        end
+        pcall(function() socketutil:reset_timeout() end)
+    end
+    -- Fallback: curl (available on Android, desktop)
+    local handle = io.popen(string.format(
+        "curl -s -L -H 'User-Agent: %s' -H 'Accept: application/vnd.github.v3+json' %q",
+        UA_PRODUCT, url))
+    if handle then
+        local body = handle:read("*a")
+        handle:close()
+        if body and body ~= "" then
+            local ok, data = pcall(json.decode, body)
+            if ok then return data end
+        end
+    end
+    return nil
+end
+
+function Updater.offerReleasesPage(message)
+    local url = "https://github.com/" .. GITHUB_REPO .. "/releases"
+    if Device:canOpenLink() then
+        UIManager:show(ConfirmBox:new{
+            text = message .. "\n\n" .. _("Open the releases page in a browser?"),
+            ok_text = _("Open"),
+            ok_callback = function()
+                Device:openLink(url)
+            end,
+        })
+    else
+        UIManager:show(InfoMessage:new{
+            text = message,
+            timeout = 3,
+        })
+    end
+end
+
+--- Return the available update version and zip URL, or nil if none/not checked.
+function Updater.getAvailableUpdate()
+    return _cached_version, _cached_zip_url
+end
+
+--- Fire a silent background update check if the cache is stale (>1h or never checked).
+-- Results available via getAvailableUpdate().
+-- @param on_update_found function(version): optional callback when a new version is discovered
+function Updater.checkBackground(on_update_found)
+    if _check_in_flight then return end
+    local now = os.time()
+    if _last_check_time and (now - _last_check_time) < CHECK_INTERVAL then return end
+
+    local NetworkMgr = require("ui/network/manager")
+    if not NetworkMgr:isWifiOn() then return end
+
+    _check_in_flight = true
+    _last_check_time = now
+
+    UIManager:scheduleIn(0.1, function()
+        local installed_version = Updater.getInstalledVersion()
+        local user_agent = UA_PRODUCT .. "/" .. installed_version
+
+        -- Only fetch the latest release (lightweight)
+        local release = httpGetJSON(
+            "https://api.github.com/repos/" .. GITHUB_REPO .. "/releases/latest",
+            user_agent)
+
+        _check_in_flight = false
+
+        if not release or not release.tag_name then return end
+        if release.draft or release.prerelease then return end
+
+        local ver = release.tag_name:gsub("^v", "")
+        if isNewer(ver, installed_version) then
+            _cached_version = ver
+            _cached_zip_url = nil
+            if release.assets then
+                for _i, asset in ipairs(release.assets) do
+                    if asset.name:match("%.zip$") then
+                        _cached_zip_url = asset.browser_download_url
+                        break
+                    end
+                end
+            end
+            if on_update_found then
+                on_update_found(ver)
+            end
+        else
+            _cached_version = nil
+            _cached_zip_url = nil
+        end
+    end)
+end
+
+function Updater.check(on_success)
+
+    local installed_version = Updater.getInstalledVersion()
+
+    -- runWhenOnline attempts to bring Wi-Fi up if it's currently off
+    -- (prompting per the user's KOReader Wi-Fi prefs) and runs the
+    -- callback once isOnline. If the user cancels the prompt the callback
+    -- never fires -- that's the right cancel UX so nothing more is needed
+    -- here. Also stronger than a plain isWifiOn check: catches "Wi-Fi
+    -- radio on but connection dead", which would otherwise fail later
+    -- with an HTTPS timeout.
+    local NetworkMgr = require("ui/network/manager")
+    NetworkMgr:runWhenOnline(function()
+    UIManager:show(InfoMessage:new{
+        text = _("Checking for updates..."),
+        timeout = 1,
+    })
+
+    UIManager:scheduleIn(0.1, function()
+        local user_agent = UA_PRODUCT .. "/" .. installed_version
+
+        -- Fetch all releases to gather notes between installed and latest
+        local releases = httpGetJSON(
+            "https://api.github.com/repos/" .. GITHUB_REPO .. "/releases",
+            user_agent)
+        if not releases or #releases == 0 then
+            Updater.offerReleasesPage(_("Could not check for updates."))
+            return
+        end
+
+        -- Collect releases newer than installed version
+        local new_releases = {}
+        local latest_zip_url
+        for _i, rel in ipairs(releases) do
+            if rel.draft or rel.prerelease then goto continue end
+            local ver = rel.tag_name:gsub("^v", "")
+            if isNewer(ver, installed_version) then
+                table.insert(new_releases, rel)
+                -- Find ZIP asset from the newest release
+                if not latest_zip_url and rel.assets then
+                    for _i2, asset in ipairs(rel.assets) do
+                        if asset.name:match("%.zip$") then
+                            latest_zip_url = asset.browser_download_url
+                            break
+                        end
+                    end
+                end
+            end
+            ::continue::
+        end
+
+        -- Update the background cache too
+        _last_check_time = os.time()
+        if #new_releases > 0 then
+            _cached_version = new_releases[1].tag_name:gsub("^v", "")
+            _cached_zip_url = latest_zip_url
+        else
+            _cached_version = nil
+            _cached_zip_url = nil
+        end
+
+        if #new_releases == 0 then
+            UIManager:show(InfoMessage:new{
+                text = _("Reading insights is up to date.") .. "\n\n" ..
+                    _("Version: ") .. "v" .. installed_version,
+                timeout = 3,
+            })
+            return
+        end
+
+        -- Build combined release notes (newest first)
+        local latest_version = new_releases[1].tag_name:gsub("^v", "")
+        local function stripMarkdown(text)
+            text = text:gsub("#+%s*", "")        -- strip heading markers
+            text = text:gsub("%*%*(.-)%*%*", "%1") -- strip bold
+            text = text:gsub("%*(.-)%*", "%1")     -- strip italic
+            text = text:gsub("`(.-)`", "%1")       -- strip inline code
+            return text
+        end
+        local notes = {}
+        for _i, rel in ipairs(new_releases) do
+            local header = "v" .. rel.tag_name:gsub("^v", "")
+            local body = stripMarkdown(rel.body or "")
+            table.insert(notes, header .. "\n" .. body)
+        end
+        local all_notes = table.concat(notes, "\n\n")
+
+        local TextViewer = require("ui/widget/textviewer")
+        local viewer
+        local buttons = {
+            {
+                {
+                    text = _("Close"),
+                    callback = function()
+                        UIManager:close(viewer)
+                    end,
+                },
+                {
+                    text = _("Update and restart"),
+                    callback = function()
+                        UIManager:close(viewer)
+                        if not latest_zip_url then
+                            UIManager:show(InfoMessage:new{
+                                text = _("No download available for this release."),
+                                timeout = 3,
+                            })
+                            return
+                        end
+                        Updater.install(latest_zip_url, installed_version, latest_version, on_success)
+                    end,
+                },
+            },
+        }
+        viewer = TextViewer:new{
+            title = _("Update available!"),
+            text = _("Installed: ") .. "v" .. installed_version .. "\n" ..
+                _("Latest: ") .. "v" .. latest_version .. "\n\n" ..
+                all_notes,
+            buttons_table = buttons,
+            add_default_buttons = false,
+        }
+        UIManager:show(viewer)
+    end)
+    end)
+end
+
+function Updater.install(zip_url, old_version, new_version, on_success, error_label)
+
+    local DataStorage = require("datastorage")
+    local lfs = require("libs/libkoreader-lfs")
+
+    UIManager:show(InfoMessage:new{
+        text = _("Downloading update..."),
+        timeout = 1,
+    })
+
+    UIManager:scheduleIn(0.1, function()
+        -- Download ZIP to temp location
+        local cache_dir = DataStorage:getSettingsDir() .. "/readinginsights_cache"
+        if lfs.attributes(cache_dir, "mode") ~= "directory" then
+            lfs.mkdir(cache_dir)
+        end
+        local zip_path = cache_dir .. "/" .. PLUGIN_ID .. ".zip"
+
+        -- Try LuaSocket first, fall back to curl
+        local downloaded = false
+        local ok_require, http, ltn12, socket, socketutil =
+            pcall(function()
+                return require("socket/http"),
+                       require("ltn12"),
+                       require("socket"),
+                       require("socketutil")
+            end)
+        if ok_require then
+            local file = io.open(zip_path, "wb")
+            if file then
+                local ok_dl, code = pcall(function()
+                    socketutil:set_timeout(socketutil.FILE_BLOCK_TIMEOUT, socketutil.FILE_TOTAL_TIMEOUT)
+                    local c = socket.skip(1, http.request({
+                        url = zip_url,
+                        method = "GET",
+                        headers = {
+                            ["User-Agent"] = UA_PRODUCT .. "/" .. old_version,
+                        },
+                        sink = ltn12.sink.file(file),
+                        redirect = true,
+                    }))
+                    socketutil:reset_timeout()
+                    return c
+                end)
+                if not ok_dl then
+                    pcall(function() socketutil:reset_timeout() end)
+                end
+                downloaded = ok_dl and code == 200
+            end
+        end
+        -- Fallback: curl (available on Android, desktop). The -f flag makes
+        -- curl exit non-zero on HTTP errors (e.g. 404 for a missing branch);
+        -- without it, curl would write the 404 HTML body to the zip file and
+        -- the unpack step would surface a misleading "extracting failed".
+        if not downloaded then
+            pcall(os.remove, zip_path)
+            local ret = os.execute(string.format(
+                "curl -sfL -o %q %q", zip_path, zip_url))
+            downloaded = ret == 0 or ret == true
+        end
+        if not downloaded then
+            pcall(os.remove, zip_path)
+            if error_label then
+                UIManager:show(InfoMessage:new{
+                    text = error_label,
+                    timeout = 3,
+                })
+            else
+                Updater.offerReleasesPage(_("Download failed."))
+            end
+            return
+        end
+
+        -- Extract to plugin directory (strip root folder from ZIP)
+        local plugin_path = DataStorage:getDataDir() .. "/plugins/" .. PLUGIN_ID
+        local ok, err = Device:unpackArchive(zip_path, plugin_path, true)
+        pcall(os.remove, zip_path)
+
+        if not ok then
+            UIManager:show(InfoMessage:new{
+                text = error_label or (_("Installation failed: ") .. tostring(err)),
+                timeout = 5,
+            })
+            return
+        end
+
+        -- Stamp install context (e.g. last_install_source) before the restart
+        -- prompt fires; runs only when unpack succeeded.
+        if on_success then
+            local ok_cb = pcall(on_success)
+            if not ok_cb then
+                -- Don't let a misbehaving callback abort the restart prompt.
+            end
+        end
+
+        -- Restart KOReader to load the new version
+        UIManager:show(ConfirmBox:new{
+            text = _("Reading insights updated to v") .. new_version .. ".\n\n" ..
+                _("Restart KOReader now?"),
+            ok_text = _("Restart"),
+            ok_callback = function()
+                UIManager:restartKOReader()
+            end,
+        })
+    end)
+end
+
+--- Install from a GitHub branch's archive zip.
+-- Same install pipeline as the release path; just composes a different URL.
+-- @param branch string: branch name (e.g. "feature/v3.1-test")
+-- @param on_success function or nil: fired after successful unpack
+function Updater.installBranch(branch, on_success)
+    local NetworkMgr = require("ui/network/manager")
+    NetworkMgr:runWhenOnline(function()
+        local installed_version = Updater.getInstalledVersion()
+        local zip_url = Updater.composeBranchUrl(branch)
+        local error_label = _("Could not install branch:") .. " " .. branch
+        Updater.install(zip_url, installed_version, "branch:" .. branch, on_success, error_label)
+    end)
+end
+
+--- Install the latest stable (non-prerelease) release, regardless of installed version.
+-- Used by the "Reset to latest stable release" entry: even when on a branch whose
+-- _meta.lua reports a higher version than the current release, we still want to
+-- pull the release zip and re-stamp last_install_source = "release".
+-- @param on_success function or nil: fired after successful unpack
+function Updater.installLatestStable(on_success)
+    local NetworkMgr = require("ui/network/manager")
+    NetworkMgr:runWhenOnline(function()
+    UIManager:show(InfoMessage:new{
+        text = _("Downloading latest release..."),
+        timeout = 1,
+    })
+
+    UIManager:scheduleIn(0.1, function()
+        local installed_version = Updater.getInstalledVersion()
+        local user_agent = UA_PRODUCT .. "/" .. installed_version
+        local release = httpGetJSON(
+            "https://api.github.com/repos/" .. GITHUB_REPO .. "/releases/latest",
+            user_agent)
+        if not release or not release.tag_name or release.draft or release.prerelease then
+            Updater.offerReleasesPage(_("Could not fetch latest release."))
+            return
+        end
+        local zip_url
+        if release.assets then
+            for _i, asset in ipairs(release.assets) do
+                if asset.name:match("%.zip$") then
+                    zip_url = asset.browser_download_url
+                    break
+                end
+            end
+        end
+        if not zip_url then
+            Updater.offerReleasesPage(_("Latest release has no downloadable zip."))
+            return
+        end
+        local new_version = release.tag_name:gsub("^v", "")
+        Updater.install(zip_url, installed_version, new_version, on_success)
+    end)
+    end)
+end
+
+return Updater


### PR DESCRIPTION
**Added**

- New "Updates" menu (Tools → Reading insights → Updates):
  - Check for and install new releases directly from GitHub, with release
    notes shown before updating.
  - "Notify on wake when update available" — optional silent background
    check (max once/hour), on startup and on wake from sleep.
  - "Developer updates" — install a specific dev branch, or reset back to
    the latest stable release.