### PR TITLE
Introduce heat map

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,16 @@ A full-screen scrollable overlay with a comprehensive overview of your reading h
 - **Streaks** — current and best daily & weekly reading streaks
 - **Yearly view** — hours or days read + pages, navigable by year
 - **Monthly chart** — bar chart of reading activity per month (tappable to see books)
-- **All-time totals** — cumulative hours and pages across all years
+- **All-time totals** — cumulative hours and pages across all years; tap
+  the "Total read" header to open a GitHub-style reading heatmap of the
+  most recent half-year (5 shades from no reading to that period's
+  busiest day, with a "Less…More" legend and month-start labels along the
+  top), swipeable left/right to page through older/newer half-years as
+  far back as there's data (the popup's own header shows the year, or a
+  year range if the period spans a Dec/Jan boundary)
 - **Use as sleep screen** — show this same popup instead of KOReader's own lock screen when the device suspends, with no double flash (see **Sleep screen** below)
 
-**Controls:** swipe left/right to change year, tap bars to open book lists, tap the chart header to toggle hours/days mode, long-press to force-reload data.
+**Controls:** swipe left/right to change year, tap the "Total read" header to open the reading heatmap, tap bars to open book lists, tap the chart header to toggle hours/days mode, long-press to force-reload data.
 
 **Caching:** uses a stale-while-revalidate strategy — the popup opens instantly with cached data while fresh values load in the background. The last known values are also mirrored to disk, so this still holds true for the very first popup open after a KOReader restart — no blocking "Loading data..." wait.
 
@@ -115,9 +121,10 @@ Once installed, future updates can be installed in-app — see
     sleep-screen popup takes over on suspend
   - **Colors** — pick your own hex color for every bar/line/label the two
     popups draw (active/inactive bars, the 8-week trend line, section/
-    column separator lines, and the label/value/section/chart-label text
-    colors); each one can be reset back to its black-on-gray default
-    individually or all at once.
+    column separator lines, the label/value/section/chart-label text
+    colors, and the 5 year-heatmap shades - defaulting to 0/25/50/75/100%
+    black); each one can be reset back to its default individually or all
+    at once.
   - **Fonts** — pick your own font (name + size) for every text role in
     both popups, grouped under **Reading insights** (section headers,
     values, labels, chart/axis labels) and **Book progress** (section

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 More screenshots
 
-<img width="96" height="128" alt="reading-insights-v2-0-0-new-book-progress-popup-colors-v0-zoh19sw42rbh1" src="https://github.com/user-attachments/assets/52f851b7-8955-4739-b3a7-96ff8c2cbfe6" /><img width="96" height="128" alt="FileManager_2026-06-30_074746" src="https://github.com/user-attachments/assets/cf248698-75d0-4948-8d9c-70ea5c69fd5e" /><img width="96" height="128" alt="FileManager_2026-07-02_083320" src="https://github.com/user-attachments/assets/8193ba8b-7f7e-4b35-9efb-81d0d4a1df8e" /><img width="96" height="128" alt="FileManager_2026-07-02_083306" src="https://github.com/user-attachments/assets/3026267b-d29d-4487-99a5-6efdcc4baa37" /><img width="96" height="128" alt="FileManager_2026-07-02_083257" src="https://github.com/user-attachments/assets/8a5857fb-f313-4d04-ab26-f604bdee7e52" />
+<img width="96" height="128" alt="reading-insights-v2-0-0-new-book-progress-popup-colors-v0-zoh19sw42rbh1" src="https://github.com/user-attachments/assets/52f851b7-8955-4739-b3a7-96ff8c2cbfe6" /><img width="96" height="128" alt="FileManager_2026-06-30_074746" src="https://github.com/user-attachments/assets/cf248698-75d0-4948-8d9c-70ea5c69fd5e" /><img width="96" height="128" alt="FileManager_2026-07-02_083320" src="https://github.com/user-attachments/assets/8193ba8b-7f7e-4b35-9efb-81d0d4a1df8e" /><img width="96" height="128" alt="FileManager_2026-07-02_083306" src="https://github.com/user-attachments/assets/3026267b-d29d-4487-99a5-6efdcc4baa37" />
+<img width="96" height="128" alt="FileManager_2026-07-02_083257" src="https://github.com/user-attachments/assets/8a5857fb-f313-4d04-ab26-f604bdee7e52" /><img width="96" height="128" alt="FileManager_2026-07-09_124519" src="https://github.com/user-attachments/assets/151433ca-e506-41e0-b9ea-af8f7d9595c7" />
+
 
 This plugin bundles two reading-stats popups, powered by KOReader's
 statistics database.
@@ -23,10 +25,11 @@ A full-screen scrollable overlay with a comprehensive overview of your reading h
 - **All-time totals** — cumulative hours and pages across all years; tap
   the "Total read" header to open a GitHub-style reading heatmap of the
   most recent half-year (5 shades from no reading to that period's
-  busiest day, with a "Less…More" legend and month-start labels along the
-  top), swipeable left/right to page through older/newer half-years as
-  far back as there's data (the popup's own header shows the year, or a
-  year range if the period spans a Dec/Jan boundary)
+  busiest day, with month-start labels along the top and Mon/Wed/Fri
+  labels down the left side), swipeable left/right to page through
+  older/newer half-years as far back as there's data (the popup's own
+  header shows the year, or a year range on its own line if the period
+  spans a Dec/Jan boundary)
 - **Use as sleep screen** — show this same popup instead of KOReader's own lock screen when the device suspends, with no double flash (see **Sleep screen** below)
 
 **Controls:** swipe left/right to change year, tap the "Total read" header to open the reading heatmap, tap bars to open book lists, tap the chart header to toggle hours/days mode, long-press to force-reload data.

--- a/_meta.lua
+++ b/_meta.lua
@@ -12,5 +12,5 @@ return {
     -- Bumped by the in-app updater (updater.lua) as new versions are
     -- installed. Keep in sync with the GitHub release tag (without the
     -- leading "v") each time a new release is cut.
-    version = "3.1.1",
+    version = "3.2.0",
 }

--- a/colors.lua
+++ b/colors.lua
@@ -14,6 +14,11 @@ settings driving every chart/diagram and label in the plugin:
   value         "value" font role   (the big numbers)
   section       "section" font role (section headers, year header)
   small         "small" font role   (chart axis/value labels, small print)
+  heatmap_0     year heatmap cell color - no reading (0% of the year's peak day)
+  heatmap_25    year heatmap cell color - low activity   (up to 25% of the peak day)
+  heatmap_50    year heatmap cell color - medium activity (up to 50% of the peak day)
+  heatmap_75    year heatmap cell color - high activity   (up to 75% of the peak day)
+  heatmap_100   year heatmap cell color - peak activity   (75-100% of the peak day)
 
 Colors are stored as "#RRGGBB" hex strings in G_reader_settings - the same
 format KOReader itself accepts (see Blitbuffer.colorFromString), so any
@@ -121,8 +126,22 @@ function ColorBar:paintTo(bb, x, y)
     end
 end
 
--- Order the "Colors" menu is built in.
-local KEY_ORDER = { "active_bar", "inactive_bar", "trend_line", "separator", "label", "value", "section", "small" }
+-- Order the "Colors" menu is built in (flat entries only - the 5 heatmap
+-- shades live in their own "Heatmap" submenu, see HEATMAP_KEY_ORDER below).
+local KEY_ORDER = {
+    "active_bar", "inactive_bar", "trend_line", "separator", "label", "value", "section", "small",
+}
+
+-- The year-heatmap shades, grouped together under one "Heatmap" submenu
+-- entry in the Colors menu instead of being listed flat alongside the
+-- other colors (there are 5 of them, one per activity level).
+local HEATMAP_KEY_ORDER = { "heatmap_0", "heatmap_25", "heatmap_50", "heatmap_75", "heatmap_100" }
+
+-- Every color key that exists, flat + heatmap combined - used wherever the
+-- code needs to touch *all* colors (e.g. "reset all colors to default").
+local ALL_KEY_ORDER = {}
+for _, key in ipairs(KEY_ORDER) do table.insert(ALL_KEY_ORDER, key) end
+for _, key in ipairs(HEATMAP_KEY_ORDER) do table.insert(ALL_KEY_ORDER, key) end
 
 -- These match what was previously hard-coded directly in the two view
 -- files (Blitbuffer.COLOR_BLACK = "#000000", Blitbuffer.COLOR_GRAY = "#AAAAAA"),
@@ -137,6 +156,14 @@ local DEFAULTS = {
     value        = "#000000",
     section      = "#000000",
     small        = "#000000",
+    -- Year heatmap cell shades, each named after its percentage of black
+    -- (0% = white/no reading that day, 100% = pure black = the day(s)
+    -- with the most reading time in the shown year).
+    heatmap_0    = "#FFFFFF",
+    heatmap_25   = "#BFBFBF",
+    heatmap_50   = "#808080",
+    heatmap_75   = "#404040",
+    heatmap_100  = "#000000",
 }
 
 local SETTINGS_PREFIX = "reading_insights_color_"
@@ -233,6 +260,11 @@ function M.label()       return M.getColor("label")        end
 function M.value()       return M.getColor("value")        end
 function M.section()     return M.getColor("section")      end
 function M.small()       return M.getColor("small")        end
+function M.heatmap0()    return M.getColor("heatmap_0")    end
+function M.heatmap25()   return M.getColor("heatmap_25")   end
+function M.heatmap50()   return M.getColor("heatmap_50")   end
+function M.heatmap75()   return M.getColor("heatmap_75")   end
+function M.heatmap100()  return M.getColor("heatmap_100")  end
 
 -- Menu ---------------------------------------------------------------
 
@@ -246,6 +278,11 @@ local function labelFor(key)
         value        = _("Value color"),
         section      = _("Section color"),
         small        = _("Chart label color"),
+        heatmap_0    = _("No reading (0%)"),
+        heatmap_25   = _("Low activity (25%)"),
+        heatmap_50   = _("Medium activity (50%)"),
+        heatmap_75   = _("High activity (75%)"),
+        heatmap_100  = _("Peak activity (100%)"),
     }
     return labels[key] or key
 end
@@ -298,6 +335,21 @@ local function showHexInputDialog(key, touchmenu_instance, on_change)
     dialog:onShowKeyboard()
 end
 
+-- Returns the sub_item_table for one flat color entry (used both for the
+-- top-level Colors menu items and for the entries inside the "Heatmap"
+-- submenu, which share the exact same "tap to edit hex" behaviour).
+local function colorItem(key, on_change)
+    return {
+        text_func = function()
+            return labelFor(key) .. ": " .. M.getHex(key)
+        end,
+        keep_menu_open = true,
+        callback = function(touchmenu_instance)
+            showHexInputDialog(key, touchmenu_instance, on_change)
+        end,
+    }
+end
+
 -- Returns the sub_item_table for a "Colors" menu entry. on_change (optional)
 -- is invoked every time a color is changed or reset, so the caller can e.g.
 -- close/refresh any currently open popup. The menu itself is always kept
@@ -305,16 +357,19 @@ end
 function M.buildMenu(on_change)
     local sub_item_table = {}
     for _, key in ipairs(KEY_ORDER) do
-        table.insert(sub_item_table, {
-            text_func = function()
-                return labelFor(key) .. ": " .. M.getHex(key)
-            end,
-            keep_menu_open = true,
-            callback = function(touchmenu_instance)
-                showHexInputDialog(key, touchmenu_instance, on_change)
-            end,
-        })
+        table.insert(sub_item_table, colorItem(key, on_change))
     end
+
+    local heatmap_sub_item_table = {}
+    for _, key in ipairs(HEATMAP_KEY_ORDER) do
+        table.insert(heatmap_sub_item_table, colorItem(key, on_change))
+    end
+    table.insert(sub_item_table, {
+        text = _("Reading heatmap"),
+        keep_menu_open = true,
+        sub_item_table = heatmap_sub_item_table,
+    })
+
     table.insert(sub_item_table, {
         text = _("Reset all colors to default"),
         keep_menu_open = true,
@@ -324,7 +379,7 @@ function M.buildMenu(on_change)
                 text = _("Reset all colors to their default values?"),
                 ok_text = _("Reset"),
                 ok_callback = function()
-                    for _, key in ipairs(KEY_ORDER) do
+                    for _, key in ipairs(ALL_KEY_ORDER) do
                         M.resetToDefault(key)
                     end
                     if touchmenu_instance then touchmenu_instance:updateItems() end

--- a/insights_view.lua
+++ b/insights_view.lua
@@ -17,9 +17,18 @@ Sections:
   - Streaks       current and best daily/weekly streaks
   - Year          time, days read, or books read + pages, navigable by year
   - Monthly chart bar chart per month (hours, days, or books mode, tappable)
-  - Total read    all-time totals
+  - Total read    all-time totals (tap header to open the reading heatmap)
 
 Gestures:
+  - Tap "Total read" header            open a GitHub-style heatmap of the
+                                        most recent half-year of reading
+                                        activity; swipe left/right inside
+                                        that popup to page through older/
+                                        newer half-years as far back as
+                                        there's data (the popup's header
+                                        shows the year, or the year range
+                                        if the half-year spans a Dec/Jan
+                                        boundary)
   - Tap yearly value or monthly bar    open book list for that period
   - Tap monthly chart header           cycle hours/days/books mode
   - Tap on Streak                      show the streak period date and some more stats
@@ -200,6 +209,7 @@ local _cache = {
     last_week_daily_minute = nil,
     last8weeks        = nil,
     last8weeks_minute = nil,
+    daily_data        = nil,
 }
 
 local _yearly_cache  = {}
@@ -235,6 +245,7 @@ local function clearAllCache()
     _cache.last_week_daily_minute = nil
     _cache.last8weeks        = nil
     _cache.last8weeks_minute = nil
+    _cache.daily_data        = nil
     _yearly_cache          = {}
     _monthly_cache         = {}
     _yearly_base_cache     = {}
@@ -882,6 +893,10 @@ local function buildYearHeader(font_section, layout, year_range, selected_year)
         face = font_section,
         fgcolor = Colors.section(),
     }
+    -- Year navigation is done via swipe on the whole popup (see
+    -- onSwipe/_goToYear); the reading heatmap now opens from the
+    -- "Total read" header instead of from tapping the year (see
+    -- showReadingHeatmap and buildInsightsSections).
 
     local function makeSlot(yr, arrow_glyph, left, visible)
         if not visible then
@@ -1411,6 +1426,250 @@ end
 function WeeklyTrendPopup:onTap()           UIManager:close(self) return true end
 function WeeklyTrendPopup:onSwipe()         UIManager:close(self) return true end
 function WeeklyTrendPopup:onAnyKeyPressed() UIManager:close(self) return true end
+
+-- ---------------------------------------------------------------------
+-- Reading heatmap (GitHub-style contribution grid)
+--
+-- Tapping the "Total read" header (see buildInsightsSections) opens a
+-- full-screen popup showing the most recent half-year of reading
+-- activity as a grid of small squares, one per day, shaded by how much
+-- was read that day relative to the busiest single day in the period
+-- shown:
+--   0%   (no reading)            -> Colors.heatmap0()
+--   >0-25% of the peak day       -> Colors.heatmap25()
+--   25-50%                       -> Colors.heatmap50()
+--   50-75%                       -> Colors.heatmap75()
+--   75-100%                      -> Colors.heatmap100()
+-- Each column is one week (Monday first); the row above the grid labels
+-- the column each month starts in, exactly like GitHub's own graph.
+-- The popup itself (HeatmapPopup, further below) is paginated in
+-- half-year steps, swipe left/right, as far back as there's reading
+-- data - see getHeatmapPeriodRange / heatmapMaxPeriodsBack.
+-- ---------------------------------------------------------------------
+
+-- Adds/subtracts whole calendar months from a Y/M/D triple (relying on
+-- os.time's normalisation of out-of-range month values - e.g. month=13
+-- rolls over into January of the next year - same trick used elsewhere
+-- in this file for date maths). Returns the shifted year/month/day plus
+-- the resulting timestamp (noon, to stay clear of DST edge cases).
+local function shiftMonths(year, month, day, delta)
+    local t = os.time({ year = year, month = month + delta, day = day, hour = 12 })
+    local dt = os.date("*t", t)
+    return dt.year, dt.month, dt.day, t
+end
+
+-- Inclusive [start_t, end_t] timestamps (both at hour=12) for the
+-- half-year heatmap period `periods_back` half-years before the current
+-- one: period 0 is the 6 months ending today, period 1 the 6 months
+-- before that, and so on.
+local function getHeatmapPeriodRange(periods_back)
+    local today = os.date("*t")
+    local _, _, _, end_t     = shiftMonths(today.year, today.month, today.day, -6 * periods_back)
+    local sy, sm, sd         = shiftMonths(today.year, today.month, today.day, -6 * (periods_back + 1))
+    local start_t            = os.time({ year = sy, month = sm, day = sd + 1, hour = 12 })
+    return start_t, end_t
+end
+
+-- How many half-year periods back from the current one (0) still reach
+-- into a year with recorded reading data, given the DB's oldest year
+-- (getYearRange().min_year). Small loop (a handful of iterations for
+-- any realistic reading history) rather than closed-form month maths,
+-- to stay in lockstep with getHeatmapPeriodRange's own definition of a
+-- period boundary.
+local function heatmapMaxPeriodsBack(min_year)
+    local jan1_min = os.time({ year = min_year, month = 1, day = 1, hour = 12 })
+    local periods_back = 0
+    while periods_back < 200 do
+        local _, next_end = getHeatmapPeriodRange(periods_back + 1)
+        if next_end < jan1_min then break end
+        periods_back = periods_back + 1
+    end
+    return periods_back
+end
+
+-- Lays [start_t, end_t] out into Monday-first week columns, padded at
+-- both ends so every column has a full 7 days (leading/trailing days
+-- outside the period are kept but marked in_range = false so they
+-- render as blank spacer cells rather than colored squares).
+local function buildRangeHeatmapGrid(daily_map, start_t, end_t)
+    local start_wd   = tonumber(os.date("%w", start_t))  -- 0=Sun..6=Sat
+    local mon_offset = (start_wd + 6) % 7                 -- days back to Monday
+    local grid_start = start_t - mon_offset * 86400
+
+    local end_wd     = tonumber(os.date("%w", end_t))
+    local sun_offset = (7 - end_wd) % 7                   -- days forward to Sunday
+    local grid_end   = end_t + sun_offset * 86400
+
+    local total_days = math.floor((grid_end - grid_start) / 86400) + 1
+    local num_cols   = math.ceil(total_days / 7)
+
+    local start_str = os.date("%Y-%m-%d", start_t)
+    local end_str   = os.date("%Y-%m-%d", end_t)
+
+    local cols = {}
+    local t = grid_start
+    for col = 1, num_cols do
+        local col_days = {}
+        for row = 1, 7 do
+            local dstr = os.date("%Y-%m-%d", t)
+            local _, d_month, d_day = parseDateYMD(dstr)
+            local in_range = (dstr >= start_str and dstr <= end_str)
+            col_days[row] = {
+                in_range        = in_range,
+                is_month_start  = (in_range and d_day == 1),
+                month           = d_month,
+                seconds         = daily_map[dstr] or 0,
+            }
+            t = t + 86400
+        end
+        cols[col] = col_days
+    end
+    return cols, num_cols
+end
+
+-- Picks the shade for one day's seconds, relative to max_seconds (the
+-- busiest single day anywhere in the period being shown).
+local function heatmapLevelColor(seconds, max_seconds)
+    if not seconds or seconds <= 0 or not max_seconds or max_seconds <= 0 then
+        return Colors.heatmap0()
+    end
+    local ratio = seconds / max_seconds
+    if ratio <= 0.25 then return Colors.heatmap25() end
+    if ratio <= 0.50 then return Colors.heatmap50() end
+    if ratio <= 0.75 then return Colors.heatmap75() end
+    return Colors.heatmap100()
+end
+
+-- A single heatmap square: a thin separator-colored frame with the level
+-- color filled inside, built from two overlapping ColorBars (same trick
+-- as everywhere else in this file that needs a solid-color rectangle -
+-- see Colors.newBar) rather than a bordered FrameContainer, so it keeps
+-- working with the RGB32 custom-color patch documented in colors.lua.
+local function buildHeatmapCell(cell_size, border, fill_color)
+    local inner_size = cell_size - 2 * border
+    if inner_size < 1 then inner_size = cell_size end
+    return OverlapGroup:new{
+        dimen = Geom:new{ w = cell_size, h = cell_size },
+        Colors.newBar(cell_size, cell_size, Colors.separator()),
+        CenterContainer:new{
+            dimen = Geom:new{ w = cell_size, h = cell_size },
+            Colors.newBar(inner_size, inner_size, fill_color),
+        },
+    }
+end
+
+-- Builds the month-start label row + the 7-row/num_cols-column grid for
+-- [start_t, end_t]. Returns the combined widget plus the cell_size
+-- actually used (so the legend below can draw matching squares).
+local function buildRangeHeatmapWidget(daily_map, start_t, end_t, fonts, max_width)
+    local cols, num_cols = buildRangeHeatmapGrid(daily_map, start_t, end_t)
+
+    local gap    = Screen:scaleBySize(2)
+    local border = Size.line.thin
+
+    -- Mon/Wed/Fri labels run down the left side of the grid (row 1 = Mon,
+    -- row 3 = Wed, row 5 = Fri; the in-between rows get no label, same as
+    -- GitHub's contribution graph). Reserve a fixed-width column for them
+    -- - sized to the widest of the three - before sizing the grid itself,
+    -- so the cells still fit within max_width.
+    local WEEKDAY_ROW_LABELS = { [1] = _("Mon"), [3] = _("Wed"), [5] = _("Fri") }
+    local wd_label_w = 0
+    for _, text in pairs(WEEKDAY_ROW_LABELS) do
+        local tw = TextWidget:new{ text = text, face = fonts.small }
+        wd_label_w = math.max(wd_label_w, tw:getSize().w)
+        tw:free()
+    end
+
+    local grid_width = max_width - wd_label_w - gap
+    local cell_size = math.floor((grid_width - (num_cols - 1) * gap) / num_cols)
+    local min_cell   = Screen:scaleBySize(8)
+    local max_cell   = Screen:scaleBySize(16)
+    if cell_size < min_cell then cell_size = min_cell end
+    if cell_size > max_cell then cell_size = max_cell end
+
+    local max_seconds = 0
+    for _, col_days in ipairs(cols) do
+        for _, d in ipairs(col_days) do
+            if d.in_range and d.seconds > max_seconds then max_seconds = d.seconds end
+        end
+    end
+
+    -- Month-start labels, one slot per column (same width/gap as the
+    -- grid below it so the label lines up with the column it belongs to).
+    -- Starts with a spacer matching the weekday label column + gap so it
+    -- lines up with the grid, which is shifted right by that same amount.
+    local sample_label = TextWidget:new{ text = "Xxx", face = fonts.small }
+    local label_h = sample_label:getSize().h
+    sample_label:free()
+
+    local labels_row = HorizontalGroup:new{ align = "bottom" }
+    table.insert(labels_row, HorizontalSpan:new{ width = wd_label_w + gap })
+    local last_month_labeled = nil
+    for col = 1, num_cols do
+        local label_text = nil
+        for _, d in ipairs(cols[col]) do
+            if d.is_month_start and d.month ~= last_month_labeled then
+                label_text = MONTH_NAMES_SHORT[d.month]
+                last_month_labeled = d.month
+                break
+            end
+        end
+        if label_text then
+            table.insert(labels_row, LeftContainer:new{
+                dimen = Geom:new{ w = cell_size, h = label_h },
+                TextWidget:new{ text = label_text, face = fonts.small, fgcolor = Colors.small() },
+            })
+        else
+            table.insert(labels_row, HorizontalSpan:new{ width = cell_size })
+        end
+        if col < num_cols then
+            table.insert(labels_row, HorizontalSpan:new{ width = gap })
+        end
+    end
+
+    -- 7-row grid, Monday (row 1) at the top through Sunday (row 7), each
+    -- row prefixed with its weekday label slot (blank unless it's one of
+    -- the WEEKDAY_ROW_LABELS rows).
+    local grid = VerticalGroup:new{ align = "left" }
+    for row = 1, 7 do
+        local row_group = HorizontalGroup:new{ align = "center" }
+        local wd_text = WEEKDAY_ROW_LABELS[row]
+        if wd_text then
+            table.insert(row_group, LeftContainer:new{
+                dimen = Geom:new{ w = wd_label_w, h = cell_size },
+                TextWidget:new{ text = wd_text, face = fonts.small, fgcolor = Colors.small() },
+            })
+        else
+            table.insert(row_group, HorizontalSpan:new{ width = wd_label_w })
+        end
+        table.insert(row_group, HorizontalSpan:new{ width = gap })
+
+        for col = 1, num_cols do
+            local d = cols[col][row]
+            if d.in_range then
+                table.insert(row_group,
+                    buildHeatmapCell(cell_size, border, heatmapLevelColor(d.seconds, max_seconds)))
+            else
+                table.insert(row_group, HorizontalSpan:new{ width = cell_size })
+            end
+            if col < num_cols then
+                table.insert(row_group, HorizontalSpan:new{ width = gap })
+            end
+        end
+        table.insert(grid, row_group)
+        if row < 7 then
+            table.insert(grid, VerticalSpan:new{ height = gap })
+        end
+    end
+
+    local widget = VerticalGroup:new{
+        align = "left",
+        labels_row,
+        VerticalSpan:new{ height = Size.padding.small },
+        grid,
+    }
+    return widget, cell_size
+end
 
 -- Weekly bar chart: 7 bars, index 1 = today (leftmost), index 7 = 6 days ago.
 -- Labels: "Today", "Yesterday", then weekday abbreviations.
@@ -1959,8 +2218,23 @@ local function buildInsightsSections(popup_self, streaks, yearly_stats, year_ran
         local all_book_count = all_time_stats and all_time_stats.book_count or 0
         local header_text = _("Total read")
 
+        -- Tapping the header opens the reading heatmap popup (moved here
+        -- from tapping the year, see showReadingHeatmap / buildYearHeader).
+        local total_read_header = buildSectionHeader(fonts.section, header_text, layout.full_width)
+        local tappable_total_read_header = InputContainer:new{
+            dimen = Geom:new{ x = 0, y = 0, w = total_read_header:getSize().w, h = total_read_header:getSize().h },
+            total_read_header,
+        }
+        tappable_total_read_header.ges_events = {
+            Tap = { GestureRange:new{ ges = "tap", range = tappable_total_read_header.dimen } },
+        }
+        function tappable_total_read_header:onTap()
+            popup_self:showReadingHeatmap()
+            return true
+        end
+
         addSectionWithRow(sections,
-            buildSectionHeader(fonts.section, header_text, layout.full_width),
+            tappable_total_read_header,
             all_time_row, layout, { no_bottom_line = true })
     end
 
@@ -2350,6 +2624,237 @@ function ReadingInsightsPopup:getYearlyStats(year, shared_conn)
 
     setMinuteCache(_yearly_cache, _stale_yearly, key, key .. ":minute", minute, result)
     return result
+end
+
+-- Returns a { ["YYYY-MM-DD"] = seconds_read } map covering every day in
+-- `year` that has any reading activity (days with none simply have no
+-- entry). Used to build the GitHub-style reading heatmap (a single
+-- calendar year is fetched and cached at a time; getDailyReadingDataForRange
+-- below stitches together whichever year(s) a given half-year period
+-- spans). Same dedup approach as getYearlyStats (group by book/page/day
+-- first, so a page re-read across multiple sessions on the same day
+-- isn't double counted), just grouped further down to per-day totals
+-- instead of one yearly sum. Cached per day (like getYearRange below)
+-- since the heatmap is only opened on demand, not on every popup rebuild.
+function ReadingInsightsPopup:getDailyReadingData(year, shared_conn)
+    local today = todayDateStr()
+    local cache_key = tostring(year)
+
+    if ENABLE_CACHE and _cache.daily_data and _cache.daily_data[cache_key]
+       and _cache.daily_data[cache_key].date == today then
+        return _cache.daily_data[cache_key].data
+    end
+
+    local data = withDb(shared_conn, {}, function(conn)
+        local year_str = tostring(year)
+        local sql = string.format([[
+            SELECT day, SUM(dur) AS duration
+            FROM (
+                SELECT id_book, page,
+                       date(start_time, 'unixepoch', 'localtime') AS day,
+                       SUM(duration) AS dur
+                FROM page_stat
+                WHERE strftime('%%Y', start_time, 'unixepoch', 'localtime') = '%s'
+                GROUP BY id_book, page, day
+            )
+            GROUP BY day
+        ]], year_str)
+
+        local result = {}
+        withStatement(conn, sql, function(stmt)
+            for row in stmt:rows() do
+                result[row[1]] = tonumber(row[2]) or 0
+            end
+        end)
+        return result
+    end)
+    data = data or {}
+
+    if ENABLE_CACHE then
+        _cache.daily_data = _cache.daily_data or {}
+        _cache.daily_data[cache_key] = { date = today, data = data }
+    end
+    return data
+end
+
+-- Returns a { ["YYYY-MM-DD"] = seconds_read } map for the inclusive date
+-- range [start_t, end_t] (timestamps at hour=12), by fetching every
+-- calendar year the range touches via getDailyReadingData (1 or 2 years
+-- for a half-year heatmap period) and filtering each down to just the
+-- days inside the range.
+function ReadingInsightsPopup:getDailyReadingDataForRange(start_t, end_t, shared_conn)
+    local year_start = tonumber(os.date("%Y", start_t))
+    local year_end   = tonumber(os.date("%Y", end_t))
+    local start_str  = os.date("%Y-%m-%d", start_t)
+    local end_str    = os.date("%Y-%m-%d", end_t)
+
+    local merged = {}
+    for year = year_start, year_end do
+        local year_map = self:getDailyReadingData(year, shared_conn)
+        for dstr, seconds in pairs(year_map) do
+            if dstr >= start_str and dstr <= end_str then
+                merged[dstr] = seconds
+            end
+        end
+    end
+    return merged
+end
+
+-- Builds the box_content (title + grid + legend + best-day line) for the
+-- "Reading heatmap" popup showing the half-year period `periods_back`
+-- half-years before the current one (0 = most recent, ending today - see
+-- getHeatmapPeriodRange). The title shows just the year, or a "start–end"
+-- year range if the period spans a Dec/Jan boundary. Also returns
+-- whether an older/newer period exists, so HeatmapPopup can gate
+-- swipe navigation.
+local function buildHeatmapBoxContent(popup_self, periods_back)
+    local start_t, end_t = getHeatmapPeriodRange(periods_back)
+    local daily_map = popup_self:getDailyReadingDataForRange(start_t, end_t)
+
+    local fonts = getCachedFonts()
+    local inner_padding = Size.padding.large
+    local box_width      = math.floor(Screen:getWidth() * 0.94)
+    local content_width  = box_width - 2 * inner_padding
+
+    local year_start = tonumber(os.date("%Y", start_t))
+    local year_end   = tonumber(os.date("%Y", end_t))
+    local year_text  = (year_start == year_end)
+        and tostring(year_end)
+        or (tostring(year_start) .. "–" .. tostring(year_end))
+
+    -- Year always sits on its own line below the heading (rather than
+    -- only falling back to two lines when the wide two-year variant like
+    -- "2025–2026" wouldn't fit on one line next to the title).
+    local title_widget = VerticalGroup:new{
+        align = "center",
+        TextWidget:new{ text = _("Reading heatmap"), face = fonts.section, fgcolor = Colors.section() },
+        VerticalSpan:new{ height = Size.padding.small },
+        TextWidget:new{ text = year_text, face = fonts.label, fgcolor = Colors.label() },
+    }
+    local title_centered = CenterContainer:new{
+        dimen = Geom:new{ w = content_width, h = title_widget:getSize().h }, title_widget,
+    }
+
+    local heatmap_widget = buildRangeHeatmapWidget(daily_map, start_t, end_t, fonts, content_width)
+
+    local content = VerticalGroup:new{
+        align = "center",
+        title_centered,
+        VerticalSpan:new{ height = Size.padding.large + Size.padding.default },
+        heatmap_widget,
+    }
+
+    local box = FrameContainer:new{
+        background     = Blitbuffer.COLOR_WHITE,
+        bordersize     = Size.border.window,
+        radius         = Size.radius.window,
+        padding_top    = inner_padding,
+        padding_bottom = inner_padding,
+        padding_left   = inner_padding,
+        padding_right  = inner_padding,
+        content,
+    }
+
+    local min_year        = popup_self:getYearRange().min_year
+    local older_available = periods_back < heatmapMaxPeriodsBack(min_year)
+    local newer_available  = periods_back > 0
+
+    return box, older_available, newer_available
+end
+
+-- Full-screen "Reading heatmap" popup, paginated in half-year steps.
+-- Unlike the other full-screen popups in this file (WeeklyTrendPopup),
+-- a single tap does close it, but swipe left/right pages between
+-- half-year periods instead of closing (mirrors the main popup's own
+-- swipe-to-change-year convention - see ReadingInsightsPopup:onSwipe),
+-- and swipe down / any other key closes.
+local HeatmapPopup = InputContainer:extend{
+    modal        = true,
+    popup_self   = nil,   -- the ReadingInsightsPopup, for data access
+    periods_back = 0,     -- 0 = most recent half-year, ending today
+}
+
+function HeatmapPopup:init()
+    local screen_w = Screen:getWidth()
+    local screen_h = Screen:getHeight()
+    self.dimen = Geom:new{ x = 0, y = 0, w = screen_w, h = screen_h }
+
+    if Device:isTouchDevice() then
+        self.ges_events.Tap   = { GestureRange:new{ ges = "tap",   range = self.dimen } }
+        self.ges_events.Swipe = { GestureRange:new{ ges = "swipe", range = self.dimen } }
+    end
+    if Device:hasKeys() then
+        self.key_events.AnyKeyPressed = { { Device.input.group.Any } }
+    end
+
+    self:_rebuild()
+end
+
+function HeatmapPopup:_rebuild()
+    local box, older_available, newer_available = buildHeatmapBoxContent(self.popup_self, self.periods_back)
+    self.box_content      = box
+    self._older_available = older_available
+    self._newer_available = newer_available
+    self[1] = CenterContainer:new{
+        dimen = self.dimen,
+        self.box_content,
+    }
+end
+
+function HeatmapPopup:onShow()
+    UIManager:setDirty(self, function()
+        return "ui", self.box_content.dimen
+    end)
+    return true
+end
+
+function HeatmapPopup:onCloseWidget()
+    UIManager:setDirty(nil, function()
+        return "ui", self.box_content.dimen
+    end)
+end
+
+-- delta: -1 = newer (toward today), +1 = older. No-op (but still
+-- consumes the gesture) once there's nothing further in that direction.
+function HeatmapPopup:_goToPeriod(delta)
+    if delta < 0 and not self._newer_available then return true end
+    if delta > 0 and not self._older_available then return true end
+
+    self.periods_back = self.periods_back + delta
+    self:_rebuild()
+    UIManager:setDirty(self, function()
+        return "ui", self.box_content.dimen
+    end)
+    return true
+end
+
+function HeatmapPopup:onTap()
+    UIManager:close(self)
+    return true
+end
+
+function HeatmapPopup:onSwipe(arg, ges_ev)
+    if not ges_ev then UIManager:close(self) return true end
+    local dir = ges_ev.direction
+    if dir == "west" or dir == "left"  then return self:_goToPeriod(-1) end
+    if dir == "east" or dir == "right" then return self:_goToPeriod(1)  end
+    UIManager:close(self)
+    return true
+end
+
+function HeatmapPopup:onAnyKeyPressed(_, key)
+    if key and key:match({ { "RPgBack", "LPgBack", "Left"  } }) then return self:_goToPeriod(1)  end
+    if key and key:match({ { "RPgFwd",  "LPgFwd",  "Right" } }) then return self:_goToPeriod(-1) end
+    UIManager:close(self)
+    return true
+end
+
+-- Opens the "Reading heatmap" popup - tap the "Total read" header (see
+-- buildInsightsSections) to open it, starting on the most recent
+-- half-year; swipe left/right inside the popup to page through older/
+-- newer half-years as far back as there's data.
+function ReadingInsightsPopup:showReadingHeatmap()
+    UIManager:show(HeatmapPopup:new{ popup_self = self, periods_back = 0 })
 end
 
 -- Returns { min_year, max_year } from the DB, cached per day.

--- a/l10n/en.po
+++ b/l10n/en.po
@@ -691,3 +691,27 @@ msgstr "Could not fetch latest release."
 
 msgid "Latest release has no downloadable zip."
 msgstr "Latest release has no downloadable zip."
+
+msgid "Reading heatmap"
+msgstr "Reading heatmap"
+
+msgid "Less"
+msgstr "Less"
+
+msgid "More"
+msgstr "More"
+
+msgid "No reading (0%)"
+msgstr "No reading (0%)"
+
+msgid "Low activity (25%)"
+msgstr "Low activity (25%)"
+
+msgid "Medium activity (50%)"
+msgstr "Medium activity (50%)"
+
+msgid "High activity (75%)"
+msgstr "High activity (75%)"
+
+msgid "Peak activity (100%)"
+msgstr "Peak activity (100%)"

--- a/l10n/hu.po
+++ b/l10n/hu.po
@@ -706,3 +706,27 @@ msgstr "Nem sikerült lekérni a legújabb kiadást."
 
 msgid "Latest release has no downloadable zip."
 msgstr "A legújabb kiadáshoz nincs letölthető zip fájl."
+
+msgid "Reading heatmap"
+msgstr "Olvasási hőtérkép"
+
+msgid "Less"
+msgstr "Kevesebb"
+
+msgid "More"
+msgstr "Több"
+
+msgid "No reading (0%)"
+msgstr "Nincs olvasás (0%)"
+
+msgid "Low activity (25%)"
+msgstr "Alacsony aktivitás (25%)"
+
+msgid "Medium activity (50%)"
+msgstr "Közepes aktivitás (50%)"
+
+msgid "High activity (75%)"
+msgstr "Magas aktivitás (75%)"
+
+msgid "Peak activity (100%)"
+msgstr "Csúcsaktivitás (100%)"


### PR DESCRIPTION
**New** 

- "Reading heatmap" popup (GitHub-style contribution grid): tap the "Total read" header to open it, showing the current half-year of reading activity in 5 shades from no-reading to peak-day.