### PR TITLE
V3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,11 @@ Once installed, future updates can be installed in-app — see
       section/column separator lines, the label/value/section/
       chart-label text colors, and the 5 year-heatmap shades - defaulting
       to 0/25/50/75/100% black); each one can be reset back to its
-      default individually or all at once.
+      default individually or all at once. Each color can be set either by
+      typing a hex code directly, or by tapping **Pick with color wheel**
+      to open a touch color wheel (hue/saturation dial plus a brightness
+      slider) that opens pre-set to the color's current value and shows a
+      live preview + hex readout while you drag.
     - **Fonts** — pick your own font (name + size) for every text role in
       both popups, grouped under **Reading insights** (section headers,
       values, labels, chart/axis labels) and **Book progress** (section
@@ -205,6 +209,9 @@ Once installed, future updates can be installed in-app — see
 - `colors.lua` — shared chart/text color settings (the "Colors" submenu)
   used by both views, so there's a single place to configure every
   color.
+- `colorwheelwidget.lua` — the touch color wheel dialog (hue/saturation
+  wheel + brightness slider + live hex preview) used by the "Pick with
+  color wheel" option in the Colors submenu.
 - `fonts.lua` — shared font settings (the "Fonts" submenu) used by both
   views, so there's a single place to configure every text role's font
   name and size.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A per-book overlay showing detailed progress and pace for the book you're curren
   with no reading are left blank — no bar at all); tap a day to see its
   exact pages/time/percent, swipe or use the arrows to page between
   months. What the small text under each day number shows is configurable
-  (*Settings → Advanced settings → Calendar cell content*):
+  (*Settings → Advanced settings → Book calendar cell content*):
   - **Percent** (default) — cumulative progress through the whole book as
     of that day, e.g. "+13%"
   - **Pages** — that day's own page count, e.g. "+101" + the localized
@@ -96,12 +96,14 @@ Reading insights can replace KOReader's own sleep/lock screen with itself, so
 the last thing you see before the device sleeps is your reading progress
 instead of a generic cover or logo.
 
-- **Use as sleep screen** (*Settings → Use as sleep screen*): **Off**
-  (default), **Only when locking from the file manager** (book view keeps
-  your normal screensaver), or **File manager and book view** (always).
-- **Transition** (*Settings → Use as sleep screen → Transition*): **Instant**
-  (default) or **Slight delay (0.1s)**, in case some other plugin/screensaver
-  setup needs a moment before this popup takes over.
+- **Enable it** from KOReader's own screen: *Settings → Screen → Sleep
+  screen → Wallpaper → **Reading insights*** (a radio option alongside
+  "Document cover", "Random image", "Leave screen as-is", etc.) — this is
+  the same `screensaver_type` setting core uses for all of its own
+  wallpaper choices, so it plays nicely with anything else that reads it.
+- **Sleep-screen indicator** (*Settings → Advanced settings*, top entry):
+  **None** (default) or **"(sleeping…)" after the title**, appended to the
+  popup's title while it's shown as the sleep screen.
 - No double flash: while active, KOReader's own screensaver (including any
   "Sleeping" message overlay) is fully suppressed for that suspend/resume
   cycle and cleanly restored afterwards — so only this popup's own single
@@ -152,9 +154,6 @@ Once installed, future updates can be installed in-app — see
   book view only), and, below a separator, a **Settings** submenu and an
   **Updates** submenu (see [Updates](#updates) above).
   - **Settings** holds:
-    - **Use as sleep screen** — Off / File manager only / File manager +
-      book (see [Sleep screen](#-sleep-screen) above), plus nested
-      **Transition** (Instant / Slight delay) and **Indicator** options
     - **Full-screen refresh on open/close** — toggle
     - **Colors** — pick your own hex color for every bar/line/label the
       two popups draw (active/inactive bars, the 8-week trend line,
@@ -174,6 +173,9 @@ Once installed, future updates can be installed in-app — see
       or type a custom font name/alias manually; each role can be reset
       to its bundled default individually or all at once.
     - **Advanced settings** holds:
+      - **Sleep-screen indicator** — None (default) or "(sleeping…)" after
+        the title, appended while the popup is shown as the sleep screen
+        (see [Sleep screen](#-sleep-screen) above)
       - **Bar chart height** — per-chart bar height (Reading insights: Last
         week / Months; Book progress: Chapters)
       - **Reading heatmap range** — how many months the calendar/time-of-
@@ -187,9 +189,9 @@ Once installed, future updates can be installed in-app — see
         any duration of 24h or more (yearly/streak totals, weekly
         averages, all-time totals, book progress) is shown as a day count
         with one decimal place (e.g. "1.2 days") instead of clock time
-      - **Calendar cell content** — Percent (default), Pages, or Time;
-        controls what the per-book reading calendar's day cells show (see
-        [Reading calendar](#-book-progress-stats) above)
+      - **Book calendar cell content** — Percent (default), Pages, or
+        Time; controls what the per-book reading calendar's day cells show
+        (see [Reading calendar](#-book-progress-stats) above)
 - **Gestures/shortcuts:** all three actions below are registered with
   `Dispatcher`, so they can be assigned under *Settings → Taps and
   gestures*:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ A per-book overlay showing detailed progress and pace for the book you're curren
 - **Pace** — your average reading speed for this book (pages/hour or minutes/page)
 - **Estimated finish** — projected time or date to finish, based on recent pace
 - **Session stats** — time spent reading this book today and across recent sessions
+- **This chapter / Next chapter** — estimated reading time left in the
+  current chapter and reading time for the next one; tap either value to
+  switch to pages left in this chapter / next chapter's page count instead
+  — tap again to switch back
 - **Chapter breakdown** — progress and time spent per chapter (if chapter metadata is available)
 - **Reading calendar** — tap the "Pace" section title (or use the "Show Book
   progress calendar" menu entry/gesture — see [Where it shows
@@ -79,8 +83,10 @@ A per-book overlay showing detailed progress and pace for the book you're curren
     KOReader's global *Duration format* setting (classic "0:23", modern
     "23'", or letters "23m")
 
-**Controls:** tap to toggle between percentage/page view, tap the "Pace"
-title to open the reading calendar, long-press to force-reload data.
+**Controls:** tap to toggle between percentage/page view, tap the "This
+chapter"/"Next chapter" row to toggle between reading time and pages left,
+tap the "Pace" title to open the reading calendar, long-press to
+force-reload data.
 
 **Caching:** shares the same stale-while-revalidate approach as Reading insights — instant open with cached data, refreshed in the background.
 

--- a/_meta.lua
+++ b/_meta.lua
@@ -12,5 +12,5 @@ return {
     -- Bumped by the in-app updater (updater.lua) as new versions are
     -- installed. Keep in sync with the GitHub release tag (without the
     -- leading "v") each time a new release is cut.
-    version = "3.4.4",
+    version = "3.5.0",
 }

--- a/colors.lua
+++ b/colors.lua
@@ -55,6 +55,26 @@ local Widget      = require("ui/widget/widget")
 local L10N = ...
 local _ = L10N._
 
+-- Load ColorWheelWidget from this plugin's own directory (not on
+-- package.path, so require() won't find it) - same loadfile() pattern
+-- main.lua uses for its own module files.
+local function pluginDir()
+    local src = debug.getinfo(1, "S").source
+    local dir = src:match("^@(.*/)")
+    return dir or "./"
+end
+
+local function loadLocal(name)
+    local path = pluginDir() .. name
+    local chunk, err = loadfile(path)
+    if not chunk then
+        error(("Reading Insights: failed to load %s: %s"):format(name, tostring(err)))
+    end
+    return chunk()
+end
+
+local ColorWheelWidget = loadLocal("colorwheelwidget.lua")
+
 -- ---------------------------------------------------------------------
 -- Custom hex colors need bb:paintRectRGB32, not bb:paintRect.
 --
@@ -178,6 +198,31 @@ local function normalizeHex(hex)
     return nil
 end
 
+-- Converts a "#RRGGBB" hex string to HSV (hue 0..360, saturation/value
+-- 0..1), so the color wheel can open already pointing at whatever color
+-- is currently set for `key`, instead of always resetting to red.
+local function hexToHsv(hex)
+    local n = normalizeHex(hex) or "#000000"
+    local r = tonumber(n:sub(2, 3), 16) / 255
+    local g = tonumber(n:sub(4, 5), 16) / 255
+    local b = tonumber(n:sub(6, 7), 16) / 255
+    local max, min = math.max(r, g, b), math.min(r, g, b)
+    local delta = max - min
+    local h = 0
+    if delta > 0 then
+        if max == r then
+            h = 60 * (((g - b) / delta) % 6)
+        elseif max == g then
+            h = 60 * (((b - r) / delta) + 2)
+        else
+            h = 60 * (((r - g) / delta) + 4)
+        end
+    end
+    if h < 0 then h = h + 360 end
+    local s = (max == 0) and 0 or (delta / max)
+    return h, s, max
+end
+
 local function readHex(key)
     if G_reader_settings and G_reader_settings.readSetting then
         local n = normalizeHex(G_reader_settings:readSetting(SETTINGS_PREFIX .. key))
@@ -287,6 +332,27 @@ local function labelFor(key)
     return labels[key] or key
 end
 
+-- Opens the color wheel for `key`, pre-set to its current color. Applying
+-- it saves the resulting hex straight away (same as "Save" in the hex
+-- input dialog) and refreshes the menu/open popups the same way.
+local function showColorWheel(key, touchmenu_instance, on_change)
+    local h, s, v = hexToHsv(M.getHex(key))
+    UIManager:show(ColorWheelWidget:new{
+        title_text = labelFor(key),
+        hue        = h,
+        saturation = s,
+        value      = v,
+        cancel_text       = _("Cancel"),
+        ok_text           = _("Apply"),
+        brightness_format = _("Brightness: %d%%"),
+        callback = function(hex)
+            M.setHex(key, hex)
+            if touchmenu_instance then touchmenu_instance:updateItems() end
+            if on_change then on_change() end
+        end,
+    })
+end
+
 local function showHexInputDialog(key, touchmenu_instance, on_change)
     local dialog
     dialog = InputDialog:new{
@@ -326,6 +392,15 @@ local function showHexInputDialog(key, touchmenu_instance, on_change)
                                 text = _("Not a valid hex color code, e.g. #1E90FF."),
                             })
                         end
+                    end,
+                },
+            },
+            {
+                {
+                    text = _("Pick with color wheel"),
+                    callback = function()
+                        UIManager:close(dialog)
+                        showColorWheel(key, touchmenu_instance, on_change)
                     end,
                 },
             },

--- a/colorwheelwidget.lua
+++ b/colorwheelwidget.lua
@@ -1,0 +1,620 @@
+local Blitbuffer = require("ffi/blitbuffer")
+local Button = require("ui/widget/button")
+local CenterContainer = require("ui/widget/container/centercontainer")
+local Device = require("device")
+local FocusManager = require("ui/widget/focusmanager")
+local FrameContainer = require("ui/widget/container/framecontainer")
+local Geom = require("ui/geometry")
+local GestureRange = require("ui/gesturerange")
+local HorizontalGroup = require("ui/widget/horizontalgroup")
+local HorizontalSpan = require("ui/widget/horizontalspan")
+local MovableContainer = require("ui/widget/container/movablecontainer")
+local Size = require("ui/size")
+local TextWidget = require("ui/widget/textwidget")
+local TitleBar = require("ui/widget/titlebar")
+local UIManager = require("ui/uimanager")
+local VerticalGroup = require("ui/widget/verticalgroup")
+local VerticalSpan = require("ui/widget/verticalspan")
+local WidgetContainer = require("ui/widget/container/widgetcontainer")
+local Font = require("ui/font")
+local Screen = Device.screen
+
+------------------------------------------------------------
+
+local ColorWheelWidget = FocusManager:extend {
+    title_text           = "Pick a color",
+    width                = nil,
+    width_factor         = 0.6,
+
+    -- HSV values
+    hue                  = 0, -- 0..360
+    saturation           = 1,
+    value                = 1,
+
+    -- Whether to invert colors in night mode for accurate preview (default: true)
+    invert_in_night_mode = true,
+
+    -- Render the wheel at this fraction of full size, then scale up.
+    -- Lower values are faster but produce more visible color banding.
+    --
+    -- | draw_scale | pixels rendered | speedup vs 1.0 |
+    -- |------------|-----------------|----------------|
+    -- | 1.0        | 100%            | 1x             |
+    -- | 0.5        | 25%             | 4x             |
+    -- | 0.25       | 6.25%           | 16x            |
+    -- | 0.125      | 1.56%           | 64x            |
+    draw_scale           = 0.5,
+
+    cancel_text          = "Cancel",
+    ok_text              = "Apply",
+    -- %d is replaced with the brightness percentage. Callers that
+    -- localize UI strings can override this (e.g. "Fényerő: %d%%").
+    brightness_format    = "Brightness: %d%%",
+
+    callback             = nil,
+    cancel_callback      = nil,
+    close_callback       = nil,
+}
+
+------------------------------------------------------------
+-- HSV → RGB
+------------------------------------------------------------
+local function hsvToRgb(h, s, v)
+    local c = v * s
+    local x = c * (1 - math.abs((h / 60) % 2 - 1))
+    local m = v - c
+    local r, g, b
+    if h < 60 then
+        r, g, b = c, x, 0
+    elseif h < 120 then
+        r, g, b = x, c, 0
+    elseif h < 180 then
+        r, g, b = 0, c, x
+    elseif h < 240 then
+        r, g, b = 0, x, c
+    elseif h < 300 then
+        r, g, b = x, 0, c
+    else
+        r, g, b = c, 0, x
+    end
+    return
+        math.floor((r + m) * 255 + 0.5),
+        math.floor((g + m) * 255 + 0.5),
+        math.floor((b + m) * 255 + 0.5)
+end
+
+------------------------------------------------------------
+-- Per-radius lookup cache: hue + saturation for every pixel.
+-- Built once per unique draw_radius, survives widget rebuilds.
+-- Pixels outside the circle are marked with sat = -1.
+--
+-- Cap the cache at MAX_CACHE_ENTRIES entries (LRU eviction).
+-- Without a bound the table grows forever if draw_scale or widget
+-- size varies across the process lifetime.
+------------------------------------------------------------
+local _wheel_cache      = {}
+local _wheel_cache_keys = {} -- insertion-order list for LRU eviction
+local MAX_CACHE_ENTRIES = 8
+
+local function getWheelCache(draw_radius)
+    if _wheel_cache[draw_radius] then
+        return _wheel_cache[draw_radius]
+    end
+
+    -- Evict oldest entry when the cache is full
+    if #_wheel_cache_keys >= MAX_CACHE_ENTRIES then
+        local oldest = table.remove(_wheel_cache_keys, 1)
+        _wheel_cache[oldest] = nil
+    end
+
+    local r2    = draw_radius * draw_radius
+    local hue_t = {}
+    local sat_t = {}
+    local idx   = 0
+
+    for py = -draw_radius, draw_radius do
+        for px = -draw_radius, draw_radius do
+            idx = idx + 1
+            local dist2 = px * px + py * py
+            if dist2 <= r2 then
+                hue_t[idx] = (math.deg(math.atan2(py, px)) + 360) % 360
+                sat_t[idx] = math.sqrt(dist2) / draw_radius
+            else
+                sat_t[idx] = -1
+            end
+        end
+    end
+
+    local cache = { hue = hue_t, sat = sat_t }
+    _wheel_cache[draw_radius] = cache
+    table.insert(_wheel_cache_keys, draw_radius)
+    return cache
+end
+
+------------------------------------------------------------
+-- ColorWheel: draws the wheel into an off-screen buffer
+-- and blits it to the screen. Redraws only when value changes;
+-- hue/saturation changes only move the indicator dot.
+------------------------------------------------------------
+local ColorWheel = WidgetContainer:extend {
+    radius               = 0,
+    hue                  = 0,
+    saturation           = 1,
+    value                = 1,
+    invert_in_night_mode = true,
+    draw_scale           = 0.5,
+    _needs_redraw        = true,
+    _last_val            = nil,
+    _cached_buf          = nil,
+}
+
+function ColorWheel:init()
+    self.radius      = math.floor(self.dimen.w / 2)
+    self.dimen       = Geom:new { x = 0, y = 0, w = self.dimen.w, h = self.dimen.h }
+    self.night_mode  = self.invert_in_night_mode and Screen.night_mode
+    self.draw_radius = math.max(1, math.floor(self.radius * self.draw_scale))
+    -- Pre-warm the cache so the first paint doesn't stutter
+    getWheelCache(self.draw_radius)
+    self._needs_redraw = true
+end
+
+function ColorWheel:free()
+    if self._cached_buf then
+        self._cached_buf:free()
+        self._cached_buf = nil
+    end
+end
+
+function ColorWheel:_renderToBuffer(x, y)
+    local dr      = self.draw_radius
+    local side    = dr * 2 + 1
+    local buf     = Blitbuffer.new(side, side, Blitbuffer.TYPE_BBRGB32)
+    local bgcolor = Screen.bb:getPixel(x - 1, y - 1)
+    buf:paintRectRGB32(0, 0, side, side, bgcolor)
+
+    local cache = getWheelCache(dr)
+    local hue_t = cache.hue
+    local sat_t = cache.sat
+    local v     = self.value
+    local nm    = self.night_mode
+    local idx   = 0
+
+    for py = -dr, dr do
+        for px = -dr, dr do
+            idx = idx + 1
+            local s = sat_t[idx]
+            if s >= 0 then
+                local r, g, b = hsvToRgb(hue_t[idx], s, v)
+                if nm then r, g, b = 255 - r, 255 - g, 255 - b end
+                buf:setPixel(dr + 1 + px, dr + 1 + py,
+                    Blitbuffer.ColorRGB32(r, g, b, 0xFF))
+            end
+        end
+    end
+
+    -- Free any previous buffer before replacing it
+    if self._cached_buf then
+        self._cached_buf:free()
+    end
+    self._cached_buf   = buf
+    self._last_val     = v
+    self._needs_redraw = false
+end
+
+function ColorWheel:paintTo(bb, x, y)
+    self.dimen.x = x
+    self.dimen.y = y
+
+    if self._needs_redraw or self._last_val ~= self.value then
+        self:_renderToBuffer(x, y)
+    end
+
+    local disp_side = self.radius * 2
+
+    if self.draw_scale < 1.0 then
+        -- Scale the small buffer up to display size, then free it
+        local scaled = self._cached_buf:scale(disp_side, disp_side)
+        bb:blitFrom(scaled, x, y, 0, 0, disp_side, disp_side)
+        scaled:free()
+    else
+        bb:blitFrom(self._cached_buf, x, y, 0, 0, disp_side, disp_side)
+    end
+
+    -- Selection indicator at full display resolution (always crisp)
+    local cx    = x + self.radius
+    local cy    = y + self.radius
+    local sel_x = cx + math.floor(math.cos(math.rad(self.hue)) * self.saturation * self.radius + 0.5)
+    local sel_y = cy + math.floor(math.sin(math.rad(self.hue)) * self.saturation * self.radius + 0.5)
+
+    for py = -4, 4 do
+        for px = -4, 4 do
+            local d = px * px + py * py
+            if d <= 16 then
+                bb:setPixelClamped(sel_x + px, sel_y + py, Blitbuffer.COLOR_WHITE)
+            end
+            if d <= 9 then
+                bb:setPixelClamped(sel_x + px, sel_y + py, Blitbuffer.COLOR_BLACK)
+            end
+        end
+    end
+end
+
+function ColorWheel:updateColor(ges_pos)
+    if not self.dimen then return false end
+
+    local cx    = self.dimen.x + self.radius
+    local cy    = self.dimen.y + self.radius
+    local dx    = ges_pos.x - cx
+    local dy    = ges_pos.y - cy
+    local dist2 = dx * dx + dy * dy
+
+    if dist2 > self.radius * self.radius then return false end
+
+    self.hue        = (math.deg(math.atan2(dy, dx)) + 360) % 360
+    self.saturation = math.min(1, math.sqrt(dist2) / self.radius)
+
+    if self.update_callback then
+        self.update_callback()
+    end
+    return true
+end
+
+------------------------------------------------------------
+-- Live color preview — reads hue/sat/val at paint time,
+-- no widget rebuild needed during drag.
+------------------------------------------------------------
+local function makeLivePreview(parent, preview_size)
+    local LivePreview = WidgetContainer:extend {
+        dimen = Geom:new { w = preview_size, h = preview_size },
+    }
+    function LivePreview:paintTo(bb, x, y)
+        local r, g, b = hsvToRgb(parent.hue, parent.saturation, parent.value)
+        local nm = parent.invert_in_night_mode
+            and G_reader_settings:isTrue("night_mode")
+        if nm then r, g, b = 255 - r, 255 - g, 255 - b end
+        bb:paintRectRGB32(x, y, self.dimen.w, self.dimen.h,
+            Blitbuffer.ColorRGB32(r, g, b, 0xFF))
+    end
+
+    return LivePreview:new {}
+end
+
+------------------------------------------------------------
+-- Live hex label — reads hue/sat/val at paint time.
+------------------------------------------------------------
+local function makeLiveHexLabel(parent, face)
+    local LiveHex = WidgetContainer:extend {
+        dimen = Geom:new { w = 0, h = 0 },
+        _last_text = "",
+        _tw = nil,
+    }
+    function LiveHex:paintTo(bb, x, y)
+        local r, g, b = hsvToRgb(parent.hue, parent.saturation, parent.value)
+        local txt = string.format("#%02X%02X%02X", r, g, b)
+        -- Rebuild TextWidget only when the hex value actually changes
+        if txt ~= self._last_text or not self._tw then
+            if self._tw then self._tw:free() end
+            self._tw = TextWidget:new { text = txt, face = face }
+            self._last_text = txt
+            local sz = self._tw:getSize()
+            self.dimen.w = sz.w
+            self.dimen.h = sz.h
+        end
+        self._tw:paintTo(bb, x, y)
+    end
+
+    return LiveHex:new {}
+end
+
+------------------------------------------------------------
+-- Main dialog
+------------------------------------------------------------
+function ColorWheelWidget:init()
+    self.screen_width     = Screen:getWidth()
+    self.screen_height    = Screen:getHeight()
+    self.medium_font_face = Font:getFace("ffont")
+    self.hex_font_face    = Font:getFace("infofont", 20)
+
+    if not self.width then
+        self.width = math.floor(
+            math.min(self.screen_width, self.screen_height) * self.width_factor
+        )
+    end
+
+    self.inner_width  = self.width - 2 * Size.padding.large
+    self.button_width = math.floor(self.inner_width / 4)
+
+    if Device:isTouchDevice() then
+        self.ges_events = {
+            TapColorWheel = {
+                GestureRange:new {
+                    ges   = "tap",
+                    range = Geom:new { x = 0, y = 0,
+                        w = self.screen_width, h = self.screen_height }
+                }
+            },
+            PanColorWheel = {
+                GestureRange:new {
+                    ges   = "pan",
+                    range = Geom:new { x = 0, y = 0,
+                        w = self.screen_width, h = self.screen_height }
+                }
+            },
+            PanReleaseColorWheel = {
+                GestureRange:new {
+                    ges   = "pan_release",
+                    range = Geom:new { x = 0, y = 0,
+                        w = self.screen_width, h = self.screen_height }
+                }
+            },
+        }
+    end
+
+    self:update()
+end
+
+-- Free all owned FFI/widget resources before rebuilding the widget tree.
+function ColorWheelWidget:_freeChildren()
+    if self.color_wheel then
+        self.color_wheel:free()
+        self.color_wheel = nil
+    end
+    if self._live_hex then
+        self._live_hex:free()
+        self._live_hex = nil
+    end
+end
+
+function ColorWheelWidget:onCloseWidget()
+    self:_freeChildren()
+    -- Force a full-screen refresh of whatever's behind us (the Colors
+    -- menu, typically): closing only marks *our own* region dirty, which
+    -- isn't enough to guarantee the menu underneath repaints cleanly on
+    -- e-ink after the wheel's own bitmap has been on screen.
+    UIManager:setDirty(nil, "full")
+end
+
+function ColorWheelWidget:update()
+    -- Free previous ColorWheel (and its _cached_buf) and LiveHex
+    -- before creating new ones, so no orphaned FFI buffers are left behind.
+    self:_freeChildren()
+
+    local wheel_size    = self.width - 2 * Size.padding.large
+    local preview_size  = math.floor(wheel_size / 4)
+
+    self.color_wheel    = ColorWheel:new {
+        dimen                = Geom:new { w = wheel_size, h = wheel_size },
+        hue                  = self.hue,
+        saturation           = self.saturation,
+        value                = self.value,
+        invert_in_night_mode = self.invert_in_night_mode,
+        draw_scale           = self.draw_scale,
+        -- update_callback is NOT set here — pan bypasses update() entirely
+    }
+
+    -- Live widgets read parent's hue/sat/val at paint time; no rebuild on drag
+    self._live_preview  = makeLivePreview(self, preview_size)
+    self._live_hex      = makeLiveHexLabel(self, self.hex_font_face)
+
+    local title_bar     = TitleBar:new {
+        width            = self.width,
+        title            = self.title_text,
+        with_bottom_line = true,
+        close_button     = true,
+        close_callback   = function() self:onCancel() end,
+        show_parent      = self,
+    }
+
+    local value_minus   = Button:new {
+        text        = "−",
+        enabled     = self.value > 0,
+        width       = self.button_width,
+        show_parent = self,
+        callback    = function()
+            self.value = math.max(0, self.value - 0.1)
+            -- Brightness change requires wheel re-render: use full update()
+            self.color_wheel._needs_redraw = true
+            self:update()
+        end,
+    }
+
+    local value_plus    = Button:new {
+        text        = "＋",
+        enabled     = self.value < 1,
+        width       = self.button_width,
+        show_parent = self,
+        callback    = function()
+            self.value = math.min(1, self.value + 0.1)
+            self.color_wheel._needs_redraw = true
+            self:update()
+        end,
+    }
+
+    local value_label   = TextWidget:new {
+        text = string.format(self.brightness_format, math.floor(self.value * 100)),
+        face = self.medium_font_face,
+    }
+
+    local value_group   = HorizontalGroup:new {
+        align = "center",
+        value_minus,
+        HorizontalSpan:new { width = Size.padding.large },
+        value_label,
+        HorizontalSpan:new { width = Size.padding.large },
+        value_plus,
+    }
+
+    local preview_group = HorizontalGroup:new {
+        align = "center",
+        FrameContainer:new {
+            bordersize = Size.border.thick,
+            margin     = 0,
+            padding    = 0,
+            self._live_preview,
+        },
+        HorizontalSpan:new { width = Size.padding.large },
+        self._live_hex,
+    }
+
+    local cancel_button = Button:new {
+        text        = self.cancel_text,
+        width       = math.floor(self.width / 2) - Size.padding.large * 2,
+        show_parent = self,
+        callback    = function() self:onCancel() end,
+    }
+
+    local ok_button     = Button:new {
+        text        = self.ok_text,
+        width       = math.floor(self.width / 2) - Size.padding.large * 2,
+        show_parent = self,
+        callback    = function() self:onApply() end,
+    }
+
+    local button_row    = HorizontalGroup:new {
+        align = "center",
+        cancel_button,
+        HorizontalSpan:new { width = Size.padding.large },
+        ok_button,
+    }
+
+    local vgroup        = VerticalGroup:new {
+        align = "center",
+        title_bar,
+        VerticalSpan:new { width = Size.padding.large },
+        CenterContainer:new {
+            dimen = Geom:new {
+                w = self.width,
+                h = value_label:getSize().h + Size.padding.default,
+            },
+            value_group,
+        },
+        VerticalSpan:new { width = Size.padding.large },
+        CenterContainer:new {
+            dimen = Geom:new {
+                w = self.width,
+                h = wheel_size + Size.padding.large * 2,
+            },
+            self.color_wheel,
+        },
+        VerticalSpan:new { width = Size.padding.large },
+        CenterContainer:new {
+            dimen = Geom:new {
+                w = self.width,
+                h = preview_size + Size.padding.default,
+            },
+            preview_group,
+        },
+        VerticalSpan:new { width = Size.padding.large * 2 },
+        CenterContainer:new {
+            dimen = Geom:new {
+                w = self.width,
+                h = Size.item.height_default,
+            },
+            button_row,
+        },
+        VerticalSpan:new { width = Size.padding.default },
+    }
+
+    self.frame          = FrameContainer:new {
+        radius     = Size.radius.window,
+        bordersize = Size.border.window,
+        background = Blitbuffer.COLOR_WHITE,
+        vgroup,
+    }
+
+    self.movable        = MovableContainer:new { self.frame }
+
+    self[1]             = CenterContainer:new {
+        dimen = Geom:new {
+            x = 0, y = 0,
+            w = self.screen_width, h = self.screen_height,
+        },
+        self.movable,
+    }
+
+    UIManager:setDirty(self, "ui")
+end
+
+------------------------------------------------------------
+-- Gesture handlers
+------------------------------------------------------------
+
+-- Tap: update hue/sat.
+-- Close on tap outside the dialog.
+function ColorWheelWidget:onTapColorWheel(arg, ges_ev)
+    if not self.color_wheel.dimen or not self.frame.dimen then return true end
+
+    if ges_ev.pos:intersectWith(self.color_wheel.dimen) then
+        if self.color_wheel:updateColor(ges_ev.pos) then
+            self.hue        = self.color_wheel.hue
+            self.saturation = self.color_wheel.saturation
+            UIManager:setDirty(self, "ui")
+        end
+        return true
+    elseif not ges_ev.pos:intersectWith(self.frame.dimen) then
+        self:onCancel()
+        return true
+    end
+    return false
+end
+
+-- Pan: sync values + fast-dirty + periodic ui-dirty only the wheel region.
+function ColorWheelWidget:onPanColorWheel(arg, ges_ev)
+    if not self.color_wheel or not self.color_wheel.dimen then return false end
+
+    if ges_ev.pos:intersectWith(self.color_wheel.dimen) then
+        if self.color_wheel:updateColor(ges_ev.pos) then
+            self.hue        = self.color_wheel.hue
+            self.saturation = self.color_wheel.saturation
+
+            self._pan_tick  = (self._pan_tick or 0) + 1
+            local mode      = (self._pan_tick % 8 == 0) and "ui" or "fast"
+
+            UIManager:setDirty(self, mode)
+        end
+        return true
+    end
+    return false
+end
+
+-- Pan release: one clean "ui" refresh to fix A2 ghosting,
+-- plus a full update() so the hex label and preview sync up.
+function ColorWheelWidget:onPanReleaseColorWheel(arg, ges_ev)
+    if not self.color_wheel or not self.color_wheel.dimen then return false end
+
+    if ges_ev.pos:intersectWith(self.color_wheel.dimen) then
+        self:update() -- rebuilds widget tree with final hue/sat; does "ui" dirty
+        return true
+    end
+    return false
+end
+
+function ColorWheelWidget:onApply()
+    UIManager:close(self)
+    if self.callback then
+        local r, g, b = hsvToRgb(self.hue, self.saturation, self.value)
+        self.callback(string.format("#%02X%02X%02X", r, g, b))
+    end
+    if self.close_callback then self.close_callback() end
+    return true
+end
+
+function ColorWheelWidget:onCancel()
+    UIManager:close(self)
+    if self.cancel_callback then self.cancel_callback() end
+    if self.close_callback then self.close_callback() end
+    return true
+end
+
+function ColorWheelWidget:onShow()
+    -- "full" (flashing) refresh, not "ui": this dialog replaces whatever
+    -- was on screen before it (typically the hex-entry InputDialog), and
+    -- a partial "ui" refresh isn't guaranteed to clear that previous
+    -- content's ghosting on e-ink, especially right after another widget
+    -- just closed in the same tick. One flash on open is a fair trade for
+    -- a clean background.
+    UIManager:setDirty(self, "full")
+    return true
+end
+
+return ColorWheelWidget

--- a/l10n/de.po
+++ b/l10n/de.po
@@ -605,6 +605,12 @@ msgstr "Voraussichtliches Ende:"
 msgid "Use as sleep screen"
 msgstr "Als Schlafbildschirm verwenden"
 
+msgid "Reading insights sleep screen"
+msgstr "Lesestatistik-Ruhebildschirm"
+
+msgid "Sleep-screen indicator"
+msgstr "Ruhebildschirm-Anzeige"
+
 msgid "Off"
 msgstr "Aus"
 
@@ -785,8 +791,8 @@ msgstr "Maximale Aktivität (100 %)"
 msgid "Show long durations (24h+) as days"
 msgstr "Lange Zeitspannen (24 Std. oder mehr) als Tage anzeigen"
 
-msgid "Calendar cell content"
-msgstr "Inhalt der Kalenderzellen"
+msgid "Book calendar cell content"
+msgstr "Inhalt der Buchkalenderzellen"
 
 msgid "Percent"
 msgstr "Prozent"

--- a/l10n/de.po
+++ b/l10n/de.po
@@ -177,6 +177,15 @@ msgstr "Daten werden neu geladen..."
 msgid "Reading insights"
 msgstr "Leseeinblicke"
 
+msgid "Reading insights: all time statistics"
+msgstr "Leseeinblicke: Gesamtstatistik"
+
+msgid "Reading insights: current book progress"
+msgstr "Leseeinblicke: aktueller Buchfortschritt"
+
+msgid "Reading insights: current book calendar"
+msgstr "Leseeinblicke: aktueller Buchkalender"
+
 msgid "All books read %1"
 msgstr "Alle gelesenen Bücher %1"
 

--- a/l10n/de.po
+++ b/l10n/de.po
@@ -411,6 +411,12 @@ msgstr "Seite"
 msgid "pages"
 msgstr "Seiten"
 
+msgid "page left"
+msgstr "Seite verbleibend"
+
+msgid "pages left"
+msgstr "Seiten verbleibend"
+
 msgid "page per minute"
 msgstr "Seite pro Minute"
 

--- a/l10n/de.po
+++ b/l10n/de.po
@@ -501,6 +501,15 @@ msgstr "Standard"
 msgid "Save"
 msgstr "Speichern"
 
+msgid "Pick with color wheel"
+msgstr "Mit Farbrad auswählen"
+
+msgid "Apply"
+msgstr "Übernehmen"
+
+msgid "Brightness: %d%%"
+msgstr "Helligkeit: %d%%"
+
 msgid "Enter a hex color code (e.g. #1E90FF), the way KOReader expects it."
 msgstr "Gib einen hexadezimalen Farbcode ein (z. B. #1E90FF), wie ihn KOReader erwartet."
 

--- a/l10n/en.po
+++ b/l10n/en.po
@@ -605,6 +605,12 @@ msgstr "Expected finish:"
 msgid "Use as sleep screen"
 msgstr "Use as sleep screen"
 
+msgid "Reading insights sleep screen"
+msgstr "Reading insights sleep screen"
+
+msgid "Sleep-screen indicator"
+msgstr "Sleep-screen indicator"
+
 msgid "Off"
 msgstr "Off"
 
@@ -785,8 +791,8 @@ msgstr "Peak activity (100%)"
 msgid "Show long durations (24h+) as days"
 msgstr "Show long durations (24h+) as days"
 
-msgid "Calendar cell content"
-msgstr "Calendar cell content"
+msgid "Book calendar cell content"
+msgstr "Book calendar cell content"
 
 msgid "Percent"
 msgstr "Percent"

--- a/l10n/en.po
+++ b/l10n/en.po
@@ -411,6 +411,12 @@ msgstr "page"
 msgid "pages"
 msgstr "pages"
 
+msgid "page left"
+msgstr "page left"
+
+msgid "pages left"
+msgstr "pages left"
+
 msgid "page per minute"
 msgstr "page per minute"
 

--- a/l10n/en.po
+++ b/l10n/en.po
@@ -501,6 +501,15 @@ msgstr "Default"
 msgid "Save"
 msgstr "Save"
 
+msgid "Pick with color wheel"
+msgstr "Pick with color wheel"
+
+msgid "Apply"
+msgstr "Apply"
+
+msgid "Brightness: %d%%"
+msgstr "Brightness: %d%%"
+
 msgid "Enter a hex color code (e.g. #1E90FF), the way KOReader expects it."
 msgstr "Enter a hex color code (e.g. #1E90FF), the way KOReader expects it."
 

--- a/l10n/en.po
+++ b/l10n/en.po
@@ -177,6 +177,15 @@ msgstr "Reloading data..."
 msgid "Reading insights"
 msgstr "Reading insights"
 
+msgid "Reading insights: all time statistics"
+msgstr "Reading insights: all time statistics"
+
+msgid "Reading insights: current book progress"
+msgstr "Reading insights: current book progress"
+
+msgid "Reading insights: current book calendar"
+msgstr "Reading insights: current book calendar"
+
 msgid "All books read %1"
 msgstr "All books read %1"
 

--- a/l10n/hu.po
+++ b/l10n/hu.po
@@ -620,6 +620,12 @@ msgstr "Várható befejezés:"
 msgid "Use as sleep screen"
 msgstr "Használat alvó képernyőként"
 
+msgid "Reading insights sleep screen"
+msgstr "Olvasási áttekintés alvó képernyő"
+
+msgid "Sleep-screen indicator"
+msgstr "Alvó képernyő jelzés"
+
 msgid "Off"
 msgstr "Ki"
 
@@ -800,8 +806,8 @@ msgstr "Csúcsaktivitás (100%)"
 msgid "Show long durations (24h+) as days"
 msgstr "24 óra feletti időtartamok napokban"
 
-msgid "Calendar cell content"
-msgstr "Naptár cella tartalma"
+msgid "Book calendar cell content"
+msgstr "Könyv naptár cella tartalma"
 
 msgid "Percent"
 msgstr "Százalék"

--- a/l10n/hu.po
+++ b/l10n/hu.po
@@ -516,6 +516,15 @@ msgstr "Alapértelmezett"
 msgid "Save"
 msgstr "Mentés"
 
+msgid "Pick with color wheel"
+msgstr "Kiválasztás színkerékkel"
+
+msgid "Apply"
+msgstr "Alkalmaz"
+
+msgid "Brightness: %d%%"
+msgstr "Fényerő: %d%%"
+
 msgid "Enter a hex color code (e.g. #1E90FF), the way KOReader expects it."
 msgstr "Add meg a szín hex kódját (pl. #1E90FF), ahogy a KOReader is kezeli."
 

--- a/l10n/hu.po
+++ b/l10n/hu.po
@@ -426,6 +426,12 @@ msgstr "oldal"
 msgid "pages"
 msgstr "oldal"
 
+msgid "page left"
+msgstr "hátralévő oldal"
+
+msgid "pages left"
+msgstr "hátralévő oldal"
+
 msgid "page per minute"
 msgstr "oldal percenként"
 

--- a/l10n/hu.po
+++ b/l10n/hu.po
@@ -177,6 +177,15 @@ msgstr "Adatok újraolvasása..."
 msgid "Reading insights"
 msgstr "Olvasási áttekintés"
 
+msgid "Reading insights: all time statistics"
+msgstr "Olvasási áttekintés: összesített statisztika"
+
+msgid "Reading insights: current book progress"
+msgstr "Olvasási áttekintés: aktuális könyv haladása"
+
+msgid "Reading insights: current book calendar"
+msgstr "Olvasási áttekintés: aktuális könyv naptára"
+
 msgid "All books read %1"
 msgstr "Összesen: %1 könyv olvasva"
 

--- a/main.lua
+++ b/main.lua
@@ -32,19 +32,19 @@ local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local Device = require("device")
 local Screen = Device.screen
 
--- Sleep-screen setting: "off" (default), "filemanager" (only when locking
--- from the file manager, i.e. no book open), or "always" (file manager and
--- book view alike). Stored as a single G_reader_settings key so it survives
--- restarts, same as every other setting in this plugin.
-local SCREENSAVER_SETTING = "readinginsights_screensaver_mode"
+--[[
+Sleep-screen integration.
 
-local function readScreensaverMode()
-    return G_reader_settings:readSetting(SCREENSAVER_SETTING) or "off"
-end
-
-local function saveScreensaverMode(mode)
-    G_reader_settings:saveSetting(SCREENSAVER_SETTING, mode)
-end
+Reading insights now registers itself as a genuine value of KOReader's own
+"screensaver_type" setting - the same global setting its own Settings >
+Screen > Sleep screen menu writes to for "Cover", "Random image", etc. -
+instead of keeping a separate on/off setting and overriding/restoring
+screensaver_type behind the scenes on every suspend/resume. See
+patchCoreScreensaver() below for how the core Screensaver module is taught
+to recognize this value, and addToMainMenu() for how "Reading insights"
+gets added as a selectable entry directly in that core menu.
+]]--
+local SCREENSAVER_TYPE_VALUE = "readinginsights"
 
 -- What to show in the title, in place of the (hidden) close button, while
 -- acting as a sleep screen: "none" (default) or "text" (appends something
@@ -57,22 +57,6 @@ end
 
 local function saveScreensaverLabelMode(mode)
     G_reader_settings:saveSetting(SCREENSAVER_LABEL_SETTING, mode)
-end
-
--- Whether to wait a beat before showing the sleep-screen popup on suspend:
--- "none" (default - shows immediately, since the core screensaver no
--- longer paints anything once suppressed - see suppressCoreScreensaver()
--- below) or "delay" (the old behaviour: wait 0.1s first, in case some
--- other plugin/core codepath still ends up painting something first that
--- the popup should sit on top of instead of racing against).
-local SCREENSAVER_DELAY_SETTING = "readinginsights_screensaver_delay_mode"
-
-local function readScreensaverDelayMode()
-    return G_reader_settings:readSetting(SCREENSAVER_DELAY_SETTING) or "none"
-end
-
-local function saveScreensaverDelayMode(mode)
-    G_reader_settings:saveSetting(SCREENSAVER_DELAY_SETTING, mode)
 end
 
 --[[
@@ -119,91 +103,63 @@ local function saveCheckUpdates(value)
 end
 
 --[[
-Suppressing KOReader's own built-in sleep screen for the duration of a
-single suspend, so it doesn't paint (full e-ink refresh) and then get
-immediately replaced by our own popup (another full refresh) a moment
-later - the "flash of the other sleep screen" effect.
+Teaching KOReader's own core Screensaver module about the "readinginsights"
+screensaver_type value, so that once it's selected in Settings > Screen >
+Sleep screen, the core Power/Suspend codepath resolves it correctly on its
+own - no runtime save-then-restore of screensaver_type spanning the actual
+suspend/resume window, and therefore nothing that can be left stuck if a
+session crashes mid-sleep.
 
-This is only ever applied right before showing our own popup in onSuspend()
-below, and undone again in onResume(), so it's scoped to exactly the
-suspend/resume window where our popup is actually going to be shown. If,
-say, the sleep-screen mode is "filemanager" and the device suspends while a
-book is open, _screensaverShouldShow() is false, these functions are never
-called, and the user's own built-in screensaver (cover/image/message/etc.)
-runs completely untouched, as if this plugin didn't exist.
+Screensaver:setup() (called by core, straight off the raw Power/Suspend
+input event, well before the "Suspend" event is ever broadcast to widgets)
+normally just copies G_reader_settings' screensaver_type into
+self.screensaver_type and resolves any fallbacks for a handful of
+hardcoded values it knows about (e.g. "readingprogress" falling back to
+"random_image" if the Statistics plugin isn't available - see core's own
+screensaver.lua). It doesn't know "readinginsights", so left alone it
+would just fall through every branch untouched.
 
-Two separate core settings need overriding, not just one: screensaver_type
-== "disable" alone is *not* enough to stop KOReader's Screensaver:show()
-from painting something - if screensaver_show_message is also on, it still
-draws its own "Sleeping" text box on top of the (disabled) background
-before anything else happens, i.e. exactly the flash this is meant to
-avoid. Both are saved/restored together as a single override.
+This patch resolves our own value the same way core resolves its own
+built-in ones, with one wrinkle: for the "book view falls back to Cover"
+case, rather than reimplementing core's cover-mode resource setup
+ourselves (image lookup, background mode, etc. - all internal to setup()),
+it's simplest and most robust to let core's own logic do that work: swap
+the *global* setting to "cover" for the duration of this single, synchronous
+call to the original setup() (wrapped in pcall so the swap is always
+undone, even if setup() itself errors), then put "readinginsights" straight
+back before this function returns - well before "Suspend" is broadcast and
+before the next suspend can possibly happen. That's a same-call-stack
+round-trip, not a save-now/restore-later spanning an actual sleep, so
+there's no crash-recovery bookkeeping needed the way the old override had.
 
-SCREENSAVER_OVERRIDE_ACTIVE_SETTING guards against overwriting the saved
-"previous value" a second time if suppressCoreScreensaver() were ever
-called twice without a restore in between, and also lets init() detect and
-clean up a leftover override from a session that crashed or was killed
-between onSuspend() and onResume() - without it, the user's built-in
-screensaver could otherwise stay stuck disabled.
+Guarded by Screensaver._readinginsights_patched so re-instantiating this
+plugin (book view + file manager both load it) only wraps setup() once.
+
+Only applies to plain suspend (event == nil): poweroff/reboot use their
+own separate sleep-screen resolution in core, which this plugin has never
+hooked into and still doesn't.
 ]]--
-local SCREENSAVER_OVERRIDE_ACTIVE_SETTING  = "readinginsights_screensaver_override_active"
-local SCREENSAVER_PREV_TYPE_SETTING        = "readinginsights_screensaver_prev_type"
-local SCREENSAVER_PREV_SHOW_MSG_SETTING    = "readinginsights_screensaver_prev_show_message"
+local function patchCoreScreensaver()
+    local Screensaver = require("ui/screensaver")
+    if Screensaver._readinginsights_patched then return end
+    Screensaver._readinginsights_patched = true
 
-local function suppressCoreScreensaver()
-    -- If our override is already flagged active, check whether the live
-    -- screensaver_type is still what we forced it to ("disable"). If the
-    -- user has since gone into KOReader's own Settings > Screen > Sleep
-    -- screen menu and changed it there, the live value will no longer be
-    -- "disable" even though our flag says "already applied". In that case
-    -- our previously saved "prev" snapshot is stale - it holds whatever
-    -- was set *before* the user's latest change, not the user's latest
-    -- change itself. Re-snapshot now so we don't clobber it later in
-    -- restoreCoreScreensaver().
-    if G_reader_settings:isTrue(SCREENSAVER_OVERRIDE_ACTIVE_SETTING) then
-        if G_reader_settings:readSetting("screensaver_type") == "disable" then
-            return -- already applied, and still ours - nothing to do
+    local orig_setup = Screensaver.setup
+    Screensaver.setup = function(self, event, event_message)
+        if event ~= nil then
+            return orig_setup(self, event, event_message)
         end
-        -- else: fall through and re-snapshot the user's new live value
-    end
-    G_reader_settings:saveSetting(SCREENSAVER_PREV_TYPE_SETTING, G_reader_settings:readSetting("screensaver_type"))
-    G_reader_settings:saveSetting(SCREENSAVER_PREV_SHOW_MSG_SETTING, G_reader_settings:isTrue("screensaver_show_message"))
-    G_reader_settings:makeTrue(SCREENSAVER_OVERRIDE_ACTIVE_SETTING)
-    G_reader_settings:saveSetting("screensaver_type", "disable")
-    G_reader_settings:makeFalse("screensaver_show_message")
-end
-
-local function restoreCoreScreensaver()
-    if not G_reader_settings:isTrue(SCREENSAVER_OVERRIDE_ACTIVE_SETTING) then return end
-    -- If the live screensaver_type is no longer "disable", the user must
-    -- have gone into KOReader's own Sleep screen menu and changed it
-    -- themselves while our override was active. That live value is what
-    -- the user actually wants now, so leave it untouched instead of
-    -- overwriting it with our (now stale) saved prev_type - just clear
-    -- our bookkeeping keys as if the override never happened.
-    if G_reader_settings:readSetting("screensaver_type") ~= "disable" then
-        G_reader_settings:delSetting(SCREENSAVER_PREV_TYPE_SETTING)
-        G_reader_settings:delSetting(SCREENSAVER_PREV_SHOW_MSG_SETTING)
-        G_reader_settings:makeFalse(SCREENSAVER_OVERRIDE_ACTIVE_SETTING)
-        return
-    end
-    G_reader_settings:saveSetting("screensaver_type", G_reader_settings:readSetting(SCREENSAVER_PREV_TYPE_SETTING))
-    G_reader_settings:delSetting(SCREENSAVER_PREV_TYPE_SETTING)
-    -- Only touch screensaver_show_message if we actually recorded an
-    -- original value for it. A leftover SCREENSAVER_OVERRIDE_ACTIVE_SETTING
-    -- from an older version of this plugin (from before this setting was
-    -- tracked) would otherwise have no recorded value here, and reading a
-    -- missing setting as "false" would incorrectly force the user's real
-    -- "Show message" preference off instead of leaving it alone.
-    if G_reader_settings:has(SCREENSAVER_PREV_SHOW_MSG_SETTING) then
-        if G_reader_settings:isTrue(SCREENSAVER_PREV_SHOW_MSG_SETTING) then
-            G_reader_settings:makeTrue("screensaver_show_message")
-        else
-            G_reader_settings:makeFalse("screensaver_show_message")
+        local real_type = G_reader_settings:readSetting("screensaver_type")
+        if real_type ~= SCREENSAVER_TYPE_VALUE then
+            return orig_setup(self, event, event_message)
         end
-        G_reader_settings:delSetting(SCREENSAVER_PREV_SHOW_MSG_SETTING)
+        G_reader_settings:saveSetting("screensaver_type", "disable")
+        local ok, err = pcall(orig_setup, self, event, event_message)
+        G_reader_settings:saveSetting("screensaver_type", real_type)
+        if not ok then
+            error(err)
+        end
     end
-    G_reader_settings:makeFalse(SCREENSAVER_OVERRIDE_ACTIVE_SETTING)
 end
 
 local function pluginDir()
@@ -258,47 +214,6 @@ local ReadingInsights = WidgetContainer:extend{
     is_doc_only = false,
 }
 
---[[
-KOReader's core Screensaver:show() (the thing that paints the default
-logo / cover / message screen) runs from Device:onPowerEvent(), which
-fires directly off the Power/Suspend input event - well *before* the
-"Suspend" event is ever broadcast to widgets/plugins. That means doing
-the override only in onSuspend() below is always one step too late: the
-core screensaver has already painted (and refreshed the e-ink panel)
-with whatever screensaver_type was set *before* the user even pressed
-the power button, and our own popup then replaces it a moment later -
-the double-flash the user sees.
-
-The fix is to keep G_reader_settings.screensaver_type synced to whether
-our popup *should* show *proactively*, at every point the answer could
-have changed (plugin init, opening/closing a book, changing the sleep-
-screen setting) - not reactively at suspend time. By the time an actual
-suspend happens, the value is already correct and Screensaver:show()
-either does nothing (screensaver_type == "disable") or runs the user's
-own untouched screensaver, with no extra repaint in either case.
-
-assume_no_document lets a caller override the "is a document open"
-check for a single call: onCloseDocument (see below) fires while
-self.ui.document is technically still non-nil, but we already know
-we're on our way back to the file manager.
-]]--
-function ReadingInsights:_syncCoreScreensaverOverride(assume_no_document)
-    local mode = readScreensaverMode()
-    local should_show
-    if mode == "always" then
-        should_show = true
-    elseif mode == "filemanager" then
-        should_show = assume_no_document or not self:_hasOpenDocument()
-    else -- "off"
-        should_show = false
-    end
-    if should_show then
-        suppressCoreScreensaver()
-    else
-        restoreCoreScreensaver()
-    end
-end
-
 function ReadingInsights:onDispatcherRegisterActions()
     Dispatcher:registerAction("reading_insights_popup", {
         category = "none",
@@ -326,18 +241,134 @@ function ReadingInsights:onDispatcherRegisterActions()
     })
 end
 
+--[[
+Add "Reading insights" as a genuine selectable entry directly inside
+KOReader's own Settings > Screen > Sleep screen > Wallpaper radio group
+(alongside "Document cover", "Random image", etc.), instead of only
+inside this plugin's own Tools menu.
+
+Core builds that submenu like this (readermenu.lua / filemanagermenu.lua):
+
+    if Device:supportsScreensaver() then
+        local screensaver_sub_item_table = dofile("frontend/ui/elements/screensaver_menu.lua")
+        ...
+        self.menu_items.screensaver = { ..., sub_item_table = screensaver_sub_item_table }
+    end
+
+Note it's dofile(), not require() - core deliberately re-executes that
+file fresh every time the menu is (re)built, rather than caching it as a
+module. That means we can't reach the finished menu_items.screensaver
+table reliably from our own addToMainMenu() (its presence there depends
+on load order between plugins, which isn't guaranteed - see this
+version's changelog/commit message for the concrete failure this used to
+hit). What we *can* do reliably is hook the dofile() call itself: wrap the
+global dofile so that, only for this one specific path, the table it
+returns gets our entry appended before core ever touches it. That
+guarantees our entry is baked into menu_items.screensaver.sub_item_table
+itself, however and whenever core assembles it - no dependence on plugin
+order at all.
+
+If a device build never calls dofile() on that path in the first place
+(Device:supportsScreensaver() returning false - a real, documented
+KOReader limitation on some devices/platforms, unrelated to this plugin -
+see e.g. koreader/koreader issues #13877, #14139, #2198), this patch
+simply never fires, same as core's own Sleep screen menu never appearing
+for that device either. The Tools > Reading insights > Settings > "Use as
+sleep screen" quick toggle remains available either way.
+]]--
+local function patchScreensaverMenuBuilder()
+    if _G._readinginsights_dofile_patched then return end
+    _G._readinginsights_dofile_patched = true
+
+    local orig_dofile = dofile
+    _G.dofile = function(path, ...)
+        local result = orig_dofile(path, ...)
+        if type(path) == "string" and path:match("ui/elements/screensaver_menu%.lua$")
+                and type(result) == "table" then
+            local our_entry = {
+                text = _("Reading insights"),
+                keep_menu_open = true,
+                radio = true,
+                checked_func = function()
+                    return G_reader_settings:readSetting("screensaver_type") == SCREENSAVER_TYPE_VALUE
+                end,
+                callback = function()
+                    G_reader_settings:saveSetting("screensaver_type", SCREENSAVER_TYPE_VALUE)
+                end,
+            }
+
+            --[[
+            core's screensaver_menu.lua returns a *top-level* table with just
+            two entries - "Wallpaper" and "Sleep screen message" - each with
+            its own sub_item_table. The actual radio group we want to join
+            ("Document cover", "Random image", "Leave screen as-is", etc.,
+            all built via that file's local genMenuItem() helper, which
+            always sets radio = true) lives *inside* the "Wallpaper" entry's
+            sub_item_table, not at this top level. Simply appending to
+            `result` (the old approach) therefore landed our entry as a
+            sibling of "Wallpaper" itself, one level too high.
+
+            So: walk `result`'s entries looking for the first one whose own
+            sub_item_table contains a contiguous run of radio = true items
+            (that's "Wallpaper"), then insert our entry right before that
+            run's separator-marked item (core flags the last radio item -
+            currently "Leave screen as-is" - with separator = true to draw
+            the divider before the non-radio settings below it). That keeps
+            "Reading insights" grouped with the other wallpaper choices and
+            the divider trailing after all of them, exactly where core's own
+            options live, without hard-coding index numbers or exact label
+            text that could change between KOReader versions.
+            ]]--
+            local inserted = false
+            for _, entry in ipairs(result) do
+                if type(entry) == "table" and type(entry.sub_item_table) == "table" then
+                    local items = entry.sub_item_table
+                    local insert_at = nil
+                    for i, item in ipairs(items) do
+                        if type(item) == "table" and item.radio then
+                            if item.separator then
+                                insert_at = i
+                                break
+                            end
+                        elseif insert_at == nil and i > 1 then
+                            -- Ran into the end of a radio block with no
+                            -- separator-flagged item (shouldn't normally
+                            -- happen, but just in case) - insert here.
+                            insert_at = i
+                            break
+                        end
+                    end
+                    if insert_at then
+                        table.insert(items, insert_at, our_entry)
+                        inserted = true
+                        break
+                    end
+                end
+            end
+
+            -- Fallback: if core ever restructures this menu so the Wallpaper
+            -- radio group can't be located this way, append at the top level
+            -- as before, so the option never disappears entirely - it'll
+            -- just be a sibling of "Wallpaper" again instead of inside it.
+            if not inserted then
+                table.insert(result, our_entry)
+            end
+        end
+        return result
+    end
+end
+
 function ReadingInsights:init()
-    -- Safety net: if a previous session crashed or was force-closed between
-    -- onSuspend() and onResume(), this restores the user's own
-    -- screensaver_type now rather than leaving it stuck on "disable". A
-    -- no-op the vast majority of the time, since the override is normally
-    -- only ever active for the few hundred ms between those two events.
-    restoreCoreScreensaver()
-    -- Then immediately (re)apply it if the current context calls for it -
-    -- e.g. starting up straight into the file manager with mode ==
-    -- "filemanager" or "always" should already have it suppressed before
-    -- the very first suspend, not just from the second one onwards.
-    self:_syncCoreScreensaverOverride()
+    -- Teach core's Screensaver module about the "readinginsights"
+    -- screensaver_type value (see patchCoreScreensaver() above). Safe to
+    -- call from both the Reader-view and File-manager instantiations of
+    -- this plugin - it's a no-op after the first call.
+    patchCoreScreensaver()
+
+    -- Bake our entry into core's own Sleep screen menu at the source (see
+    -- patchScreensaverMenuBuilder() above). Also safe to call from both
+    -- instantiations - no-op after the first call.
+    patchScreensaverMenuBuilder()
 
     self.ui.menu:registerToMainMenu(self)
     self:onDispatcherRegisterActions()
@@ -379,24 +410,23 @@ function ReadingInsights:_hasOpenDocument()
     return self.ui ~= nil and self.ui.document ~= nil
 end
 
+-- True when this suspend should show the Reading insights popup itself,
+-- i.e. screensaver_type is our value.
 function ReadingInsights:_screensaverShouldShow()
-    local mode = readScreensaverMode()
-    if mode == "off" then return false end
-    if mode == "always" then return true end
-    if mode == "filemanager" then return not self:_hasOpenDocument() end
-    return false
+    return G_reader_settings:readSetting("screensaver_type") == SCREENSAVER_TYPE_VALUE
 end
 
 --[[
 Sleep-screen integration.
 
-KOReader's own sleep-screen picker (Settings > Screen > Sleep screen) is a
-fixed list rebuilt from a core file every time it's opened, and its
-"reading progress" option is hardcoded to the built-in Statistics plugin -
-there's no supported way for a third-party plugin to add itself there.
-Instead, this hooks the same Suspend/Resume events every screensaver mode
-ultimately relies on, and shows the Reading insights popup on top,
-independently of whatever G_reader_settings.screensaver_type is set to.
+"Reading insights" is a genuine selectable entry in KOReader's own
+Settings > Screen > Sleep screen menu (see addToMainMenu() below), backed
+by patchCoreScreensaver() teaching core's Screensaver module to recognize
+it. Core's own Screensaver:show() (which runs off the raw Power/Suspend
+input event, before the "Suspend" event below is even broadcast) already
+resolved screensaver_type == "disable" for this case by the time we get
+here - see patchCoreScreensaver() - so it painted nothing, and this is
+free to show the actual popup without racing or flashing against it.
 
 The popup is created with readonly = true so a stray tap, swipe-down, or
 the wake key itself can't dismiss it early while the device is still
@@ -404,58 +434,30 @@ the wake key itself can't dismiss it early while the device is still
 ]]--
 function ReadingInsights:onSuspend()
     if not self:_screensaverShouldShow() then return end
-    -- Belt-and-braces: the override should already be active by now (it's
-    -- applied proactively - see _syncCoreScreensaverOverride() and its
-    -- call sites), since by the time the "Suspend" event reaches us here,
-    -- KOReader's own Screensaver:show() has *already run* off the raw
-    -- Power/Suspend input event. This call is a no-op in the normal case;
-    -- it only matters as a fallback if some context change was missed.
-    suppressCoreScreensaver()
-    -- With the override active (screensaver_type == "disable" and
-    -- screensaver_show_message == false), KOReader's own Screensaver:show()
-    -- returns immediately without painting anything, so by default this
-    -- shows right away rather than after an artificial delay. The old
-    -- 0.1s-delay behaviour is still available (Settings > "Sleep-screen
-    -- transition") for anyone who wants to wait a beat first.
-    local function showPopup()
-        if self._screensaver_widget then return end -- already showing
-        if Device:hasEinkScreen() then
-            Screen:clear()
-            Screen:refreshFull(0, 0, Screen:getWidth(), Screen:getHeight())
-        end
-        local label_mode = readScreensaverLabelMode()
-        local screensaver_label = (label_mode == "text") and _("sleeping…") or nil
-        local popup = Insights.Popup:new{
-            ui = self.ui,
-            readonly = true,
-            screensaver_label = screensaver_label,
-        }
-        local orig_on_close_widget = popup.onCloseWidget
-        popup.onCloseWidget = function(popup_self, ...)
-            if orig_on_close_widget then orig_on_close_widget(popup_self, ...) end
-            if self._screensaver_widget == popup_self then
-                self._screensaver_widget = nil
-            end
-        end
-        self._screensaver_widget = popup
-        UIManager:show(popup, "full")
+    if self._screensaver_widget then return end -- already showing
+    if Device:hasEinkScreen() then
+        Screen:clear()
+        Screen:refreshFull(0, 0, Screen:getWidth(), Screen:getHeight())
     end
-
-    if readScreensaverDelayMode() == "delay" then
-        UIManager:scheduleIn(0.1, showPopup)
-    else
-        showPopup()
+    local label_mode = readScreensaverLabelMode()
+    local screensaver_label = (label_mode == "text") and _("sleeping…") or nil
+    local popup = Insights.Popup:new{
+        ui = self.ui,
+        readonly = true,
+        screensaver_label = screensaver_label,
+    }
+    local orig_on_close_widget = popup.onCloseWidget
+    popup.onCloseWidget = function(popup_self, ...)
+        if orig_on_close_widget then orig_on_close_widget(popup_self, ...) end
+        if self._screensaver_widget == popup_self then
+            self._screensaver_widget = nil
+        end
     end
+    self._screensaver_widget = popup
+    UIManager:show(popup, "full")
 end
 
 function ReadingInsights:onResume()
-    -- Re-sync rather than unconditionally restoring: with mode == "always"
-    -- (or "filemanager" while still in the file manager), the override is
-    -- meant to stay active across suspend/resume cycles, not just the
-    -- first one - unconditionally restoring here would undo it right
-    -- after every wake-up, bringing back the flash on every suspend after
-    -- the first.
-    self:_syncCoreScreensaverOverride()
     if self._screensaver_widget then
         UIManager:close(self._screensaver_widget)
         self._screensaver_widget = nil
@@ -641,21 +643,6 @@ function ReadingInsights:_updateSubItems()
     }
 end
 
--- A document has just finished opening (Reader view): re-sync, since
--- _hasOpenDocument() now correctly reflects "book open" and may need to
--- restore the user's own screensaver (mode == "filemanager").
-function ReadingInsights:onReaderReady()
-    self:_syncCoreScreensaverOverride()
-end
-
--- A document is about to close, heading back to the file manager.
--- self.ui.document is still non-nil at this exact point (ReaderUI clears
--- it right after broadcasting this event), so _hasOpenDocument() can't be
--- trusted here - explicitly sync as if no document were open instead.
-function ReadingInsights:onCloseDocument()
-    self:_syncCoreScreensaverOverride(true)
-end
-
 function ReadingInsights:onShowReadingInsightsPopup()
     local popup = Insights.Popup:new{ ui = self.ui }
     UIManager:show(popup)
@@ -719,97 +706,39 @@ function ReadingInsights:addToMainMenu(menu_items)
 
     local settings_sub_item_table = {}
 
+    -- Whether/how it's used as a sleep screen is normally set directly in
+    -- KOReader's own Settings > Screen > Sleep screen menu (see the
+    -- menu_items.screensaver injection at the end of this function).
+    --
+    -- That injection depends on menu_items.screensaver already existing
+    -- (with a sub_item_table) by the time this addToMainMenu() runs, which
+    -- isn't a guaranteed, documented part of KOReader's plugin API - just
+    -- an observed implementation detail. If it ever doesn't hold (older/
+    -- newer core versions, a different frontend, plugin load order, an
+    -- interaction with another sleep-screen plugin, etc.) the injection
+    -- silently does nothing, and without a fallback here there would be no
+    -- way at all to turn this on. So the same control is duplicated here,
+    -- inside our own Settings submenu, guaranteed to always work
+    -- regardless of what core's menu looks like.
+    --[[
     table.insert(settings_sub_item_table, {
-        text_func = function()
-            local mode = readScreensaverMode()
-            local mode_label = (mode == "always" and _("File manager + book"))
-                or (mode == "filemanager" and _("File manager only"))
-                or _("Off")
-            return _("Use as sleep screen") .. ": " .. mode_label
-        end,
+        text = _("Use as sleep screen"),
         keep_menu_open = true,
-        sub_item_table = {
-            {
-                text = _("Off"),
-                keep_menu_open = true,
-                radio = true,
-                checked_func = function() return readScreensaverMode() == "off" end,
-                callback = function()
-                    saveScreensaverMode("off")
-                    self:_syncCoreScreensaverOverride()
-                end,
-            },
-            {
-                text = _("Only when locking from the file manager"),
-                keep_menu_open = true,
-                radio = true,
-                checked_func = function() return readScreensaverMode() == "filemanager" end,
-                callback = function()
-                    saveScreensaverMode("filemanager")
-                    self:_syncCoreScreensaverOverride()
-                end,
-            },
-            {
-                text = _("File manager and book view"),
-                keep_menu_open = true,
-                radio = true,
-                checked_func = function() return readScreensaverMode() == "always" end,
-                callback = function()
-                    saveScreensaverMode("always")
-                    self:_syncCoreScreensaverOverride()
-                end,
-            },
-            {
-                text_func = function()
-                    return _("Transition") .. ": " ..
-                        ((readScreensaverDelayMode() == "delay") and _("Slight delay") or _("Instant"))
-                end,
-                keep_menu_open = true,
-                sub_item_table = {
-                    {
-                        text = _("Instant"),
-                        keep_menu_open = true,
-                        radio = true,
-                        checked_func = function() return readScreensaverDelayMode() == "none" end,
-                        callback = function() saveScreensaverDelayMode("none") end,
-                    },
-                    {
-                        text = _("Slight delay (0.1s)"),
-                        keep_menu_open = true,
-                        radio = true,
-                        checked_func = function() return readScreensaverDelayMode() == "delay" end,
-                        callback = function() saveScreensaverDelayMode("delay") end,
-                    },
-                },
-            },
-            {
-                text_func = function()
-                    local label_mode = readScreensaverLabelMode()
-                    return _("Indicator") .. ": " ..
-                        ((label_mode == "text") and _("\"(sleeping…)\" after the title") or _("None"))
-                end,
-                keep_menu_open = true,
-                separator = true,
-                sub_item_table = {
-                    {
-                        text = _("None"),
-                        keep_menu_open = true,
-                        radio = true,
-                        checked_func = function() return readScreensaverLabelMode() == "none" end,
-                        callback = function() saveScreensaverLabelMode("none") end,
-                    },
-                    {
-                        text = _("\"(sleeping…)\" after the title"),
-                        keep_menu_open = true,
-                        radio = true,
-                        checked_func = function() return readScreensaverLabelMode() == "text" end,
-                        callback = function() saveScreensaverLabelMode("text") end,
-                    },
-                },
-            },
-        },
-        separator = true,
+        checked_func = function()
+            return G_reader_settings:readSetting("screensaver_type") == SCREENSAVER_TYPE_VALUE
+        end,
+        callback = function()
+            if G_reader_settings:readSetting("screensaver_type") == SCREENSAVER_TYPE_VALUE then
+                G_reader_settings:saveSetting("screensaver_type", "disable")
+            else
+                G_reader_settings:saveSetting("screensaver_type", SCREENSAVER_TYPE_VALUE)
+            end
+        end,
     })
+    ]]--
+
+    -- Sleep-screen indicator now lives at the top of Advanced settings
+    -- instead of here - see advanced_settings_sub_item_table below.
 
     table.insert(settings_sub_item_table, {
         text = _("Full-screen refresh on open/close"),
@@ -880,6 +809,33 @@ function ReadingInsights:addToMainMenu(menu_items)
     -- separator is placed above this entry itself (set on the preceding
     -- "Fonts" entry) to set it apart from the rest of the Settings menu.
     local advanced_settings_sub_item_table = {}
+
+    -- Moved here (to the very top) from the Settings submenu, keeping its
+    -- separator so it still visually stands apart from the entries below.
+    table.insert(advanced_settings_sub_item_table, {
+        text_func = function()
+            local label_mode = readScreensaverLabelMode()
+            return _("Sleep-screen indicator") .. ": " ..
+                ((label_mode == "text") and _("\"(sleeping…)\" after the title") or _("None"))
+        end,
+        keep_menu_open = true,
+        sub_item_table = {
+            {
+                text = _("None"),
+                keep_menu_open = true,
+                radio = true,
+                checked_func = function() return readScreensaverLabelMode() == "none" end,
+                callback = function() saveScreensaverLabelMode("none") end,
+            },
+            {
+                text = _("\"(sleeping…)\" after the title"),
+                keep_menu_open = true,
+                radio = true,
+                checked_func = function() return readScreensaverLabelMode() == "text" end,
+                callback = function() saveScreensaverLabelMode("text") end,
+            },
+        },
+    })
 
     table.insert(advanced_settings_sub_item_table, {
         text = _("Bar chart height"),
@@ -1058,7 +1014,7 @@ function ReadingInsights:addToMainMenu(menu_items)
             local mode = (mode_key == "pages" and _("Pages"))
                 or (mode_key == "time" and _("Time"))
                 or _("Percent")
-            return _("Calendar cell content") .. ": " .. mode
+            return _("Book calendar cell content") .. ": " .. mode
         end,
         keep_menu_open = true,
         sub_item_table = {
@@ -1117,6 +1073,19 @@ function ReadingInsights:addToMainMenu(menu_items)
         sorting_hint = "tools",
         sub_item_table = sub_item_table,
     }
+
+    --[[
+    No standalone top-level "Reading insights sleep screen" entry anymore -
+    the "Reading insights" choice already lives inside KOReader's own
+    Settings > Screen > Sleep screen > Wallpaper radio group (alongside
+    "Document cover", "Random image", etc.), baked in by
+    patchScreensaverMenuBuilder() above. Having a second, separate entry
+    right next to the Sleep screen submenu just duplicated that same
+    screensaver_type toggle in a confusing spot, so it's been removed -
+    the Wallpaper-submenu entry is now the only place to pick it from
+    (besides the Tools > Reading insights > Settings > "Use as sleep
+    screen" quick toggle below, which stays).
+    ]]--
 end
 
 return ReadingInsights

--- a/main.lua
+++ b/main.lua
@@ -303,7 +303,7 @@ function ReadingInsights:onDispatcherRegisterActions()
     Dispatcher:registerAction("reading_insights_popup", {
         category = "none",
         event    = "ShowReadingInsightsPopup",
-        title    = _("Reading insights"),
+        title    = _("Reading insights: all time statistics"),
         general  = true,
     })
     -- reader = true (not general): only assignable to gestures/shortcuts
@@ -311,7 +311,7 @@ function ReadingInsights:onDispatcherRegisterActions()
     Dispatcher:registerAction("reading_stats_popup", {
         category = "none",
         event    = "ShowReadingStatsPopup",
-        title    = _("Book progress"),
+        title    = _("Reading insights: current book progress"),
         reader   = true,
     })
     -- reader = true: opens the per-book reading calendar directly (see
@@ -321,7 +321,7 @@ function ReadingInsights:onDispatcherRegisterActions()
     Dispatcher:registerAction("reading_calendar_popup", {
         category = "none",
         event    = "ShowBookCalendarPopup",
-        title    = _("Book progress calendar"),
+        title    = _("Reading insights: current book calendar"),
         reader   = true,
     })
 end

--- a/stats_view.lua
+++ b/stats_view.lua
@@ -15,14 +15,18 @@ chunk argument, so both views translate from the same l10n/<lang>.po files
 instead of each keeping a separate hard-coded translation table.
 
 Sections shown:
-  - This chapter / Next chapter   estimated time left and time to read next chapter
+  - This chapter / Next chapter   estimated time left and time to read next
+                                   chapter (tap to switch to pages left /
+                                   next chapter's page count; tap again to
+                                   switch back)
   - This book                     progress percentage, pages read, time spent, time left
   - Chapter bar                   visual bar chart of all chapters (tappable, swipeable)
   - Pace                          today's reading time and pages-per-minute rate
 
 Controls:
-  - Tap anywhere     dismiss
-  - Swipe left/right navigate the chapter bar
+  - Tap anywhere              dismiss
+  - Tap "This chapter" row    toggle between reading time left and pages left
+  - Swipe left/right          navigate the chapter bar
 ]]--
 
 local Blitbuffer = require("ffi/blitbuffer")
@@ -943,8 +947,28 @@ local function buildSections(stats, fonts, layout, popup)
         return buildValueLine(fonts.value, fonts.label, layout.col_width, time_data, label)
     end
 
-    local chapter_val1    = valueLine(stats.chapter_time_left_hhmm, _("reading time"))
-    local chapter_val2    = valueLine(stats.next_chapter_time_hhmm, _("reading time"))
+    -- "This chapter" / "Next chapter" can show either an estimated reading
+    -- time (default) or a page count - toggled by tapping the header/value
+    -- row (see ReadingStatsPopup:onTapClose). popup._chapter_view_mode is
+    -- nil/"time" by default; "pages" once toggled. Tapping again switches
+    -- back (see onTapClose).
+    local chapter_view_mode = (popup and popup._chapter_view_mode) or "time"
+    local chapter_val1, chapter_val2
+    if chapter_view_mode == "pages" then
+        local na_pages   = { value = "—", unit = "" }
+        local left_count = stats.chapter_pages_left_count
+        local left_data  = left_count and { value = formatCount(left_count), unit = "" } or na_pages
+        local left_label = N_("page left", "pages left", left_count or 0)
+        chapter_val1 = valueLine(left_data, left_label)
+
+        local next_count = stats.next_chapter_pages_count
+        local next_data  = next_count and { value = formatCount(next_count), unit = "" } or emptyValue()
+        local next_label = next_count and N_("page", "pages", next_count) or ""
+        chapter_val2 = valueLine(next_data, next_label)
+    else
+        chapter_val1 = valueLine(stats.chapter_time_left_hhmm, _("reading time left"))
+        chapter_val2 = valueLine(stats.next_chapter_time_hhmm, _("reading time"))
+    end
     local progress_label  = stats.book_progress.value ~= "" and _("read") or ""
     local book_progress   = valueLine(stats.book_progress, progress_label)
     local book_pages_read = valueLine(stats.book_pages_read, "")
@@ -963,8 +987,18 @@ local function buildSections(stats, fonts, layout, popup)
     end
     local days_col2 = valueLine(nonEmpty(today_time_data_hhmm), _("read today"))
 
-    local chapter_headers   = buildChapterHeaders(fonts.section, layout, stats.has_next_chapter)
-    local chapter_values    = buildTwoColRow(chapter_val1, chapter_val2, layout, not stats.has_next_chapter)
+    local chapter_headers_content = buildChapterHeaders(fonts.section, layout, stats.has_next_chapter)
+    local chapter_values_content  = buildTwoColRow(chapter_val1, chapter_val2, layout, not stats.has_next_chapter)
+    -- Wrapped in tappableWrap (fixed dimen) rather than used raw, so tapping
+    -- either row reliably hits (same reasoning as started_tap/finish_tap
+    -- below: a bare HorizontalGroup isn't guaranteed a usable .dimen for
+    -- hitTest the way a FrameContainer with an explicit dimen is).
+    local chapter_headers = tappableWrap(chapter_headers_content, chapter_headers_content:getSize().w)
+    local chapter_values  = tappableWrap(chapter_values_content, chapter_values_content:getSize().w)
+    if popup then
+        popup._chapter_headers = chapter_headers
+        popup._chapter_values  = chapter_values
+    end
     local book_progress_row = buildTwoColRow(book_progress, book_pages_read, layout)
     local book_progress_tap = book_progress_row
     local book_row          = buildTwoColRow(book_col1, book_col2, layout)
@@ -1641,6 +1675,7 @@ local ReadingStatsPopup = InputContainer:extend{
     chapter_bar_offset = nil,
     today_all_books    = false,
     _has_book_id       = false,
+    _chapter_view_mode = "time",
 }
 
 function ReadingStatsPopup:init()
@@ -1737,6 +1772,8 @@ function ReadingStatsPopup:gatherStats()
         today_time_all_hhmm    = zero_hhmm,
         chapter_info           = nil,
         has_next_chapter       = false,
+        chapter_pages_left_count = nil,
+        next_chapter_pages_count = nil,
     }
 
     local ui = self.ui
@@ -1785,11 +1822,19 @@ function ReadingStatsPopup:gatherStats()
         stats.next_chapter_time_hhmm  = na_hhmm
     end
 
-    if has_stats and toc then
+    -- Page counts (chapter_pages_left_count / next_chapter_pages_count) are
+    -- computed independently of has_stats (pace data isn't needed to know
+    -- how many pages are left) so the tap-to-toggle "pages" view in
+    -- buildSections works even before the reader has enough history for a
+    -- time estimate. The *_hhmm time estimates still need avg_time.
+    if toc then
         local chapter_pages_left = getChapterPagesLeft(ui, pageno)
         if chapter_pages_left and chapter_pages_left >= 0 then
-            local ch_secs = chapter_pages_left * avg_time
-            stats.chapter_time_left_hhmm = formatTimeHHMM(ch_secs)
+            stats.chapter_pages_left_count = chapter_pages_left
+            if has_stats then
+                local ch_secs = chapter_pages_left * avg_time
+                stats.chapter_time_left_hhmm = formatTimeHHMM(ch_secs)
+            end
         end
 
         if next_chapter_start then
@@ -1802,7 +1847,8 @@ function ReadingStatsPopup:gatherStats()
             end
             next_chapter_pages = next_chapter_pages - 1
             if next_chapter_pages < 0 then next_chapter_pages = 0 end
-            if next_chapter_pages >= 0 then
+            stats.next_chapter_pages_count = next_chapter_pages
+            if has_stats then
                 local nc_secs = next_chapter_pages * avg_time
                 stats.next_chapter_time_hhmm = formatTimeHHMM(nc_secs)
             end
@@ -2030,6 +2076,12 @@ end
 function ReadingStatsPopup:onTapClose(arg, ges_ev)
     if ges_ev then
         local x, y = ges_ev.pos.x, ges_ev.pos.y
+
+        if hitTest(self._chapter_headers, x, y) or hitTest(self._chapter_values, x, y) then
+            self._chapter_view_mode = (self._chapter_view_mode == "pages") and "time" or "pages"
+            self:_rebuildUI()
+            return true
+        end
 
         if hitTest(self._this_book_header, x, y) then
             UIManager:close(self)

--- a/stats_view.lua
+++ b/stats_view.lua
@@ -86,9 +86,10 @@ local function saveChapterBarHeightSetting(value)
 end
 
 -- Book-calendar cell content setting (Settings ▸ Advanced settings ▸
--- "Calendar cell content" / "Naptár cella tartalma"). Controls what the
--- small text line under each day number in the per-book reading calendar
--- shows - see buildBookCalendarCellText below for the exact formatting:
+-- "Book calendar cell content" / "Könyv naptár cella tartalma"). Controls
+-- what the small text line under each day number in the per-book reading
+-- calendar shows - see buildBookCalendarCellText below for the exact
+-- formatting:
 --   "percent" (default) - cumulative progress, e.g. "+13%"
 --   "pages"             - that day's own page count, e.g. "+101o"
 --   "time"              - that day's own time spent, honoring KOReader's
@@ -1224,8 +1225,8 @@ local function pageAbbrev(count)
 end
 
 -- Small text line shown under the day number in the per-book calendar
--- (see buildBookCalendarGrid below). Honors the "Calendar cell content"
--- setting (readCalendarCellModeSetting):
+-- (see buildBookCalendarGrid below). Honors the "Book calendar cell
+-- content" setting (readCalendarCellModeSetting):
 --   "percent" (default) - cumulative "+13%" progress through the whole book
 --   "pages"             - that day's own page count, e.g. "+101o"
 --   "time"              - that day's own time spent, e.g. "+0:23" or


### PR DESCRIPTION
**New**

- Book progress: chapter time/pages remaining — new "This chapter / Next chapter" row showing estimated reading time left in the current chapter and the next chapter's reading time; tap either value to switch to pages-left / next chapter's page count, tap again to switch back. #

- Color picker wheel — Colors submenu now offers a touch color wheel (hue/saturation dial + brightness slider, live preview + hex readout, pre-set to the current value) as an alternative to typing a hex code. New file: colorwheelwidget.lua. #29 

**Changed** 

- Sleep screen integration overhauled: instead of the plugin's own Settings → Use as sleep screen (Off / Only from file manager / File manager + book view) with its own Transition setting, it's now enabled via KOReader's native screensaver: Settings → Screen → Sleep screen → Wallpaper → Reading insights (File manager only option removed for now because it worked hectic previously)
 
- Renamed setting: "Calendar cell content" → "Book calendar cell content"

- Sleep-screen indicator moved under Advanced Settings

- Renamed all gestures to find them easier #28 
Reading insights: all time statistics
Reading insights: current book progress
Reading insights: current book calendar