### PR TITLE
Guard book-stats/calendar queries and fix DST day drift

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -36,5 +36,5 @@ return {
     -- Bumped by the in-app updater (updater.lua) as new versions are
     -- installed. Keep in sync with the GitHub release tag (without the
     -- leading "v") each time a new release is cut.
-    version = "6.1.4",
+    version = "6.1.5",
 }

--- a/lib/book_calendar_data.lua
+++ b/lib/book_calendar_data.lua
@@ -67,63 +67,78 @@ end
 
 -- Year/month of this book's most recent page_stat entry, so the calendar
 -- opens on the month last actually read in. nil, nil if no reading yet.
+--
+-- Goes through StatsDb.withDb/withStatement (pcall-guarded, always closes)
+-- rather than a raw conn:rowexec: KOReader's statistics plugin writes to this
+-- file on every page turn, so a read here can lose that race and raise
+-- SQLITE_BUSY - which a raw rowexec would turn into a leaked connection and a
+-- failed popup. On any such failure this just falls back to "no reading yet".
 function M.getBookLastReadYearMonth(book_id)
     if not book_id then return nil, nil end
-    local conn = StatsDb.open()
-    if not conn then return nil, nil end
-
-    local sql = string.format([[
-        SELECT strftime('%%Y', start_time, 'unixepoch', 'localtime'),
-               strftime('%%m', start_time, 'unixepoch', 'localtime')
-        FROM   page_stat
-        WHERE  id_book = %d
-        ORDER  BY start_time DESC
-        LIMIT  1
-    ]], book_id)
-    local y, m = conn:rowexec(sql)
-    conn:close()
-    if not y or not m then return nil, nil end
-    return tonumber(y), tonumber(m)
+    local r = StatsDb.withDb(nil, function(conn)
+        local ym = {}
+        StatsDb.withStatement(conn, string.format([[
+            SELECT strftime('%%Y', start_time, 'unixepoch', 'localtime'),
+                   strftime('%%m', start_time, 'unixepoch', 'localtime')
+            FROM   page_stat
+            WHERE  id_book = %d
+            ORDER  BY start_time DESC
+            LIMIT  1
+        ]], book_id), function(stmt)
+            for row in stmt:rows() do
+                ym.y, ym.m = tonumber(row[1]), tonumber(row[2])
+                break
+            end
+        end)
+        return ym
+    end)
+    if not r or not r.y or not r.m then return nil, nil end
+    return r.y, r.m
 end
 
 -- This book's first-ever page_stat start_time (when reading started), or
--- nil if there's no reading data yet.
+-- nil if there's no reading data yet. Same pcall-guarded access as above.
 function M.getBookStartedTimestamp(book_id)
     if not book_id then return nil end
-    local conn = StatsDb.open()
-    if not conn then return nil end
-
-    local sql = string.format([[
-        SELECT start_time
-        FROM   page_stat
-        WHERE  id_book = %d
-        ORDER  BY start_time ASC
-        LIMIT  1
-    ]], book_id)
-    local started_timestamp = conn:rowexec(sql)
-    conn:close()
-    return started_timestamp and tonumber(started_timestamp) or nil
+    return StatsDb.withDb(nil, function(conn)
+        local ts
+        StatsDb.withStatement(conn, string.format([[
+            SELECT start_time
+            FROM   page_stat
+            WHERE  id_book = %d
+            ORDER  BY start_time ASC
+            LIMIT  1
+        ]], book_id), function(stmt)
+            for row in stmt:rows() do
+                ts = tonumber(row[1])
+                break
+            end
+        end)
+        return ts
+    end)
 end
 
 -- Whether this book has any page_stat entry in the given year/month, used
--- to stop paging back into empty months.
+-- to stop paging back into empty months. Same pcall-guarded access as above;
+-- a lost race falls back to "no data" (the arrows just won't page there).
 function M.bookCalendarMonthHasData(book_id, year, month)
     if not book_id then return false end
-    local conn = StatsDb.open()
-    if not conn then return false end
-
     local year_month = string.format("%04d-%02d", year, month)
-    local sql = string.format([[
-        SELECT EXISTS(
+    return StatsDb.withDb(false, function(conn)
+        local has = false
+        StatsDb.withStatement(conn, string.format([[
             SELECT 1 FROM page_stat
             WHERE  id_book = %d
             AND    strftime('%%Y-%%m', start_time, 'unixepoch', 'localtime') = '%s'
             LIMIT  1
-        );
-    ]], book_id, year_month)
-    local exists = conn:rowexec(sql)
-    conn:close()
-    return tonumber(exists) == 1
+        ]], book_id, year_month), function(stmt)
+            for _row in stmt:rows() do
+                has = true
+                break
+            end
+        end)
+        return has
+    end)
 end
 
 -- "How far into the book had I gotten as of the last page reached this day"

--- a/lib/book_stats_data.lua
+++ b/lib/book_stats_data.lua
@@ -22,71 +22,83 @@ local StatsDb = deps.StatsDb
 
 local M = {}
 
--- Single DB connection, all stats fetched at once.
+-- Single DB connection, all stats fetched at once. Every read goes through
+-- StatsDb.withDb/withStatement (pcall-guarded, always closes the connection):
+-- KOReader's own statistics plugin writes to this file on every page turn and
+-- book close, so a query here can lose that race and raise SQLITE_BUSY - and a
+-- raw conn:rowexec would then leak the connection and fail the whole popup.
+-- On any such failure a field is simply left nil, which the caller already
+-- treats as "no data yet".
 function M.getBookAndTodayStats(book_id)
     if not book_id then return nil, nil, nil, nil, nil, nil, nil end
 
-    local conn = StatsDb.open()
-    if not conn then return nil, nil, nil, nil, nil, nil, nil end
+    local r = StatsDb.withDb(nil, function(conn)
+        -- Reads the first row of `sql` into out[k1] (col 1) and, when k2 is
+        -- given, out[k2] (col 2), as numbers. A query that returns no row or
+        -- loses the race with KOReader's writer simply leaves them nil, which
+        -- the caller already treats as "no data yet".
+        local out = {}
+        local function readRow(sql, k1, k2)
+            StatsDb.withStatement(conn, sql, function(stmt)
+                for row in stmt:rows() do
+                    out[k1] = tonumber(row[1])
+                    if k2 then out[k2] = tonumber(row[2]) end
+                    break
+                end
+            end)
+        end
 
-    local days_sql = string.format([[
-        SELECT count(*)
-        FROM (
-            SELECT strftime('%%Y-%%m-%%d', start_time, 'unixepoch', 'localtime') AS dates
+        readRow(string.format([[
+            SELECT count(*)
+            FROM (
+                SELECT strftime('%%Y-%%m-%%d', start_time, 'unixepoch', 'localtime') AS dates
+                FROM   page_stat
+                WHERE  id_book = %d
+                GROUP  BY dates
+            );
+        ]], book_id), "total_days")
+
+        readRow(string.format([[
+            SELECT count(*), sum(duration)
+            FROM (
+                SELECT page, sum(duration) AS duration
+                FROM   page_stat
+                WHERE  strftime('%%Y-%%m-%%d', start_time, 'unixepoch', 'localtime')
+                       = strftime('%%Y-%%m-%%d', 'now', 'localtime')
+                AND    id_book = %d
+                GROUP  BY page
+            );
+        ]], book_id), "today_pages", "today_time")
+
+        readRow([[
+            SELECT count(*), sum(duration)
+            FROM (
+                SELECT page, sum(duration) AS duration
+                FROM   page_stat
+                WHERE  strftime('%Y-%m-%d', start_time, 'unixepoch', 'localtime')
+                       = strftime('%Y-%m-%d', 'now', 'localtime')
+                GROUP  BY id_book, page
+            );
+        ]], "today_pages_all", "today_time_all")
+
+        -- Days elapsed since this book's very first page_stat entry (i.e. since
+        -- reading it was started). Used for the "N days since started" cell.
+        readRow(string.format([[
+            SELECT start_time,
+                   CAST(julianday('now', 'localtime')
+                        - julianday(date(start_time, 'unixepoch', 'localtime')) AS INTEGER)
             FROM   page_stat
             WHERE  id_book = %d
-            GROUP  BY dates
-        );
-    ]], book_id)
-    local total_days = conn:rowexec(days_sql)
-    total_days = total_days and tonumber(total_days) or nil
+            ORDER  BY start_time ASC
+            LIMIT  1
+        ]], book_id), "started_timestamp", "days_since_start")
 
-    local today_book_sql = string.format([[
-        SELECT count(*), sum(duration)
-        FROM (
-            SELECT page, sum(duration) AS duration
-            FROM   page_stat
-            WHERE  strftime('%%Y-%%m-%%d', start_time, 'unixepoch', 'localtime')
-                   = strftime('%%Y-%%m-%%d', 'now', 'localtime')
-            AND    id_book = %d
-            GROUP  BY page
-        );
-    ]], book_id)
-    local today_pages, today_time = conn:rowexec(today_book_sql)
-    today_pages = tonumber(today_pages)
-    today_time  = tonumber(today_time)
+        return out
+    end)
 
-    local today_all_sql = [[
-        SELECT count(*), sum(duration)
-        FROM (
-            SELECT page, sum(duration) AS duration
-            FROM   page_stat
-            WHERE  strftime('%Y-%m-%d', start_time, 'unixepoch', 'localtime')
-                   = strftime('%Y-%m-%d', 'now', 'localtime')
-            GROUP  BY id_book, page
-        );
-    ]]
-    local today_pages_all, today_time_all = conn:rowexec(today_all_sql)
-    today_pages_all = tonumber(today_pages_all)
-    today_time_all  = tonumber(today_time_all)
-
-    -- Days elapsed since this book's very first page_stat entry (i.e. since
-    -- reading it was started). Used for the "N days since started" cell.
-    local first_read_sql = string.format([[
-        SELECT start_time,
-               CAST(julianday('now', 'localtime')
-                    - julianday(date(start_time, 'unixepoch', 'localtime')) AS INTEGER)
-        FROM   page_stat
-        WHERE  id_book = %d
-        ORDER  BY start_time ASC
-        LIMIT  1
-    ]], book_id)
-    local started_timestamp, days_since_start = conn:rowexec(first_read_sql)
-    started_timestamp = started_timestamp and tonumber(started_timestamp) or nil
-    days_since_start  = days_since_start  and tonumber(days_since_start)  or nil
-
-    conn:close()
-    return total_days, today_pages, today_time, today_pages_all, today_time_all, days_since_start, started_timestamp
+    r = r or {}
+    return r.total_days, r.today_pages, r.today_time, r.today_pages_all,
+           r.today_time_all, r.days_since_start, r.started_timestamp
 end
 
 return M

--- a/lib/insights_data.lua
+++ b/lib/insights_data.lua
@@ -1316,15 +1316,23 @@ function M.getLastWeekAll(shared_conn)
         return Cache._cache.last_week, Cache._cache.last_week_daily
     end
 
-    local now_ts  = os.time()
-    local now_t   = os.date("*t")
-    local today_midnight = now_ts - (now_t.hour * 3600 + now_t.min * 60 + now_t.sec)
-    local week_start_ts  = today_midnight - 6 * 86400
+    -- Each day's local midnight from calendar components (year/month/day - i),
+    -- not today_midnight - i*86400: os.time() normalises the components in
+    -- local time, so a 23- or 25-hour DST day still lands exactly on midnight,
+    -- whereas the fixed-86400 step would drift onto 23:00/01:00 of the wrong
+    -- day and its date_str would then miss the SQL date() grouping entirely
+    -- (that day's bar reading as 0). Same reasoning as M.dayBounds.
+    local now_t = os.date("*t")
+    local function localMidnight(day_offset)
+        return os.time{ year = now_t.year, month = now_t.month, day = now_t.day + day_offset,
+                        hour = 0, min = 0, sec = 0 }
+    end
+    local week_start_ts = localMidnight(-6)
 
     local DOW_KEYS = { [0]="Sun", [1]="Mon", [2]="Tue", [3]="Wed", [4]="Thu", [5]="Fri", [6]="Sat" }
     local date_info = {}
     for i = 0, 6 do
-        local day_midnight = today_midnight - i * 86400
+        local day_midnight = localMidnight(-i)
         local date_str = os.date("%Y-%m-%d", day_midnight)
         local dow      = tonumber(os.date("%w", day_midnight))
         local label
@@ -1426,18 +1434,26 @@ function M.getLast8WeeksData()
         return cached_val
     end
 
-    local now_ts  = os.time()
-    local now_t   = os.date("*t")
-    local today_midnight = now_ts - (now_t.hour * 3600 + now_t.min * 60 + now_t.sec)
-    local period_start_ts = today_midnight - (8 * 7 - 1) * 86400
+    -- Local midnights from calendar components, not today_midnight - N*86400:
+    -- across a 23-/25-hour DST day the fixed step drifts off midnight and the
+    -- week's start_date/end_date label would name the wrong day (and the SQL
+    -- boundary below would slip by an hour). Same reasoning as M.dayBounds and
+    -- getLastWeekAll. The day-bucketing further down stays correct on its own:
+    -- it rounds diff_days to the nearest whole day, which absorbs the DST hour.
+    local now_t = os.date("*t")
+    local function localMidnight(day_offset)
+        return os.time{ year = now_t.year, month = now_t.month, day = now_t.day + day_offset,
+                        hour = 0, min = 0, sec = 0 }
+    end
+    local today_midnight  = localMidnight(0)
+    local period_start_ts = localMidnight(-(8 * 7 - 1))
 
     local weeks = {}
     for w = 1, 8 do
-        local week_end_midnight   = today_midnight - (8 - w) * 7 * 86400
-        local week_start_midnight = week_end_midnight - 6 * 86400
+        local end_offset   = -(8 - w) * 7
         weeks[w] = {
-            start_date = os.date("%Y-%m-%d", week_start_midnight),
-            end_date   = os.date("%Y-%m-%d", week_end_midnight),
+            start_date = os.date("%Y-%m-%d", localMidnight(end_offset - 6)),
+            end_date   = os.date("%Y-%m-%d", localMidnight(end_offset)),
             seconds    = 0,
             pages      = 0,
         }


### PR DESCRIPTION
Fix: Book progress popup and calendar could fail to open (and leak a DB connection) when a query collided with KOReader's stats writer — now handled gracefully.
Fix: "Last week" and 8-week charts no longer misalign a day around daylight-saving transitions.