### PR TITLE
Add hamburger menu to insights popup, sync locale files

### DIFF
--- a/_meta.lua
+++ b/_meta.lua
@@ -36,5 +36,5 @@ return {
     -- Bumped by the in-app updater (updater.lua) as new versions are
     -- installed. Keep in sync with the GitHub release tag (without the
     -- leading "v") each time a new release is cut.
-    version = "6.4.1",
+    version = "6.4.2",
 }

--- a/lib/insights_settings.lua
+++ b/lib/insights_settings.lua
@@ -193,6 +193,13 @@ M.Opt = {
     SHOW_PACE_DATES_KEY      = "reading_insights_book_show_pace_dates",
     SHOW_PACE_DATES_DEFAULT  = true,
 
+    -- Reading insights popup: whether the title bar's hamburger menu (top
+    -- left - quick access to the streak/heatmap/records/achievements
+    -- popups) is shown at all (Settings > Advanced settings > Reading
+    -- insight popup > "Hamburger menu"). On by default.
+    SHOW_HAMBURGER_MENU_KEY     = "reading_insights_show_hamburger_menu",
+    SHOW_HAMBURGER_MENU_DEFAULT = false,
+
 }
 
 -- Reading heatmap period length (Prefs ▸ Advanced settings ▸ how many
@@ -477,6 +484,18 @@ end
 
 function M.Opt.saveShowPaceDates(value)
     M.saveBoolSetting(M.Opt.SHOW_PACE_DATES_KEY, value)
+end
+
+-- Reading insights popup's title-bar hamburger menu (Settings > Advanced
+-- settings > Reading insight popup > "Hamburger menu"). Read by
+-- insights_view.lua's _buildUI when deciding whether to draw the title
+-- bar's left icon at all.
+function M.Opt.readShowHamburgerMenu()
+    return M.readBoolSetting(M.Opt.SHOW_HAMBURGER_MENU_KEY, M.Opt.SHOW_HAMBURGER_MENU_DEFAULT)
+end
+
+function M.Opt.saveShowHamburgerMenu(value)
+    M.saveBoolSetting(M.Opt.SHOW_HAMBURGER_MENU_KEY, value)
 end
 
 function M.Opt.readAchievementRefresh()

--- a/lib/menu.lua
+++ b/lib/menu.lua
@@ -426,6 +426,16 @@ function M.build(self, deps)
     end
 
     table.insert(insights_popup_sub_item_table, {
+        text = _("Hamburger menu"),
+        help_text = _("Show the hamburger menu (top left of the title bar) with quick access to the streak, heatmap, records and achievements popups."),
+        keep_menu_open = true,
+        checked_func = function() return deps.ViewSettings.Opt.readShowHamburgerMenu() end,
+        callback = function()
+            deps.ViewSettings.Opt.saveShowHamburgerMenu(not deps.ViewSettings.Opt.readShowHamburgerMenu())
+        end,
+    })
+
+    table.insert(insights_popup_sub_item_table, {
         text_func = function()
             local months = deps.ViewSettings.readHeatmapMonthsSetting()
             local label

--- a/locale/de.po
+++ b/locale/de.po
@@ -396,6 +396,12 @@ msgstr "Lesezeit"
 msgid "per day"
 msgstr "pro Tag"
 
+msgid "second"
+msgstr "Sekunde"
+
+msgid "seconds"
+msgstr "Sekunden"
+
 msgid "minute"
 msgstr "Minute"
 
@@ -1607,6 +1613,30 @@ msgstr "Leseziel & Erfolge"
 msgid "Reading goal only"
 msgstr "Nur Leseziel"
 
+msgid "Time of day"
+msgstr "Tageszeit"
+
+msgid "Time of day view"
+msgstr "Tageszeit-Ansicht"
+
+msgid "Chart"
+msgstr "Diagramm"
+
+msgid "Heatmap"
+msgstr "Heatmap"
+
+msgid "Night"
+msgstr "Nacht"
+
+msgid "Morning"
+msgstr "Morgen"
+
+msgid "Afternoon"
+msgstr "Nachmittag"
+
+msgid "Evening"
+msgstr "Abend"
+
 msgid "Reading time by time of day"
 msgstr "Lesezeit nach Tageszeit"
 
@@ -1633,3 +1663,12 @@ msgstr "Zeile „Begonnen / voraussichtliches Ende“"
 
 msgid "Show the \"started …\" and \"expected finish\" date row in the \"Pace\" section."
 msgstr "Die Datumszeile „begonnen …“ und „voraussichtliches Ende“ im Abschnitt „Lesetempo“ anzeigen."
+
+msgid "Hamburger menu"
+msgstr "Hamburger-Menü"
+
+msgid "Show the hamburger menu (top left of the title bar) with quick access to the streak, heatmap, records and achievements popups."
+msgstr "Das Hamburger-Menü (oben links in der Titelleiste) mit schnellem Zugriff auf die Popups für Lesesträhne, Heatmap, Rekorde und Erfolge anzeigen."
+
+msgid "Couldn't open Records: "
+msgstr "Rekorde konnten nicht geöffnet werden: "

--- a/locale/en.po
+++ b/locale/en.po
@@ -1633,3 +1633,12 @@ msgstr "Started / expected finish row"
 
 msgid "Show the \"started …\" and \"expected finish\" date row in the \"Pace\" section."
 msgstr "Show the \"started …\" and \"expected finish\" date row in the \"Pace\" section."
+
+msgid "Hamburger menu"
+msgstr "Hamburger menu"
+
+msgid "Show the hamburger menu (top left of the title bar) with quick access to the streak, heatmap, records and achievements popups."
+msgstr "Show the hamburger menu (top left of the title bar) with quick access to the streak, heatmap, records and achievements popups."
+
+msgid "Couldn't open Records: "
+msgstr "Couldn't open Records: "

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -396,6 +396,12 @@ msgstr "temps de lecture"
 msgid "per day"
 msgstr "par jour"
 
+msgid "second"
+msgstr "seconde"
+
+msgid "seconds"
+msgstr "secondes"
+
 msgid "minute"
 msgstr "minute"
 
@@ -1607,6 +1613,30 @@ msgstr "Objectif de lecture et succès"
 msgid "Reading goal only"
 msgstr "Objectif de lecture uniquement"
 
+msgid "Time of day"
+msgstr "Moment de la journée"
+
+msgid "Time of day view"
+msgstr "Vue par moment de la journée"
+
+msgid "Chart"
+msgstr "Graphique"
+
+msgid "Heatmap"
+msgstr "Carte de chaleur"
+
+msgid "Night"
+msgstr "Nuit"
+
+msgid "Morning"
+msgstr "Matin"
+
+msgid "Afternoon"
+msgstr "Après-midi"
+
+msgid "Evening"
+msgstr "Soir"
+
 msgid "Reading time by time of day"
 msgstr "Temps de lecture par heure de la journée"
 
@@ -1633,3 +1663,12 @@ msgstr "Ligne Commencé / fin prévue"
 
 msgid "Show the \"started …\" and \"expected finish\" date row in the \"Pace\" section."
 msgstr "Afficher la ligne de dates « commencé … » et « fin prévue » dans la section « Rythme »."
+
+msgid "Hamburger menu"
+msgstr "Menu hamburger"
+
+msgid "Show the hamburger menu (top left of the title bar) with quick access to the streak, heatmap, records and achievements popups."
+msgstr "Afficher le menu hamburger (en haut à gauche de la barre de titre) donnant un accès rapide aux fenêtres de série de lecture, carte de chaleur, records et succès."
+
+msgid "Couldn't open Records: "
+msgstr "Impossible d'ouvrir Records : "

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -1660,3 +1660,12 @@ msgstr "„Kezdve / várható befejezés” sor"
 
 msgid "Show the \"started …\" and \"expected finish\" date row in the \"Pace\" section."
 msgstr "A „kezdve…” és „várható befejezés” dátumsor megjelenítése a „Haladás” szakaszban."
+
+msgid "Hamburger menu"
+msgstr "Hamburger menü"
+
+msgid "Show the hamburger menu (top left of the title bar) with quick access to the streak, heatmap, records and achievements popups."
+msgstr "A hamburger menü (a fejléc bal oldalán) megjelenítése, amely gyors elérést biztosít az olvasási sorozat, a hőtérkép, a rekordok és a teljesítmények popupokhoz."
+
+msgid "Couldn't open Records: "
+msgstr "Nem sikerült megnyitni a Rekordokat: "

--- a/locale/pt_PT.po
+++ b/locale/pt_PT.po
@@ -396,6 +396,12 @@ msgstr "tempo de leitura"
 msgid "per day"
 msgstr "por dia"
 
+msgid "second"
+msgstr "segundo"
+
+msgid "seconds"
+msgstr "segundos"
+
 msgid "minute"
 msgstr "minuto"
 
@@ -1607,6 +1613,30 @@ msgstr "Meta de leitura e conquistas"
 msgid "Reading goal only"
 msgstr "Apenas meta de leitura"
 
+msgid "Time of day"
+msgstr "Período do dia"
+
+msgid "Time of day view"
+msgstr "Vista por período do dia"
+
+msgid "Chart"
+msgstr "Gráfico"
+
+msgid "Heatmap"
+msgstr "Mapa de calor"
+
+msgid "Night"
+msgstr "Noite"
+
+msgid "Morning"
+msgstr "Manhã"
+
+msgid "Afternoon"
+msgstr "Tarde"
+
+msgid "Evening"
+msgstr "Noitinha"
+
 msgid "Reading time by time of day"
 msgstr "Tempo de leitura por período do dia"
 
@@ -1633,3 +1663,12 @@ msgstr "Linha \"iniciado / conclusão prevista\""
 
 msgid "Show the \"started …\" and \"expected finish\" date row in the \"Pace\" section."
 msgstr "Mostrar a linha de datas \"iniciado …\" e \"conclusão prevista\" na secção \"Ritmo\"."
+
+msgid "Hamburger menu"
+msgstr "Menu hambúrguer"
+
+msgid "Show the hamburger menu (top left of the title bar) with quick access to the streak, heatmap, records and achievements popups."
+msgstr "Mostrar o menu hambúrguer (no canto superior esquerdo da barra de título) com acesso rápido às janelas de sequência de leitura, mapa de calor, recordes e conquistas."
+
+msgid "Couldn't open Records: "
+msgstr "Não foi possível abrir os Recordes: "

--- a/locale/uk.po
+++ b/locale/uk.po
@@ -411,6 +411,12 @@ msgstr "час читання"
 msgid "per day"
 msgstr "на день"
 
+msgid "second"
+msgstr "секунда"
+
+msgid "seconds"
+msgstr "секунди"
+
 msgid "minute"
 msgstr "хвилина"
 
@@ -531,6 +537,9 @@ msgstr "Колір розділу"
 msgid "Chart label color"
 msgstr "Колір міток графіка"
 
+msgid "Section header background color"
+msgstr "Колір фону заголовка розділу"
+
 msgid "Settings"
 msgstr "Налаштування"
 
@@ -593,6 +602,9 @@ msgstr "Стрілки панелі глав"
 
 msgid "Font name"
 msgstr "Назва шрифту"
+
+msgid "Enter a bundled font file name (e.g. NotoSans-Bold.ttf) or a KOReader font alias (e.g. tfont, cfont). If it can't be found, this role falls back to its default font."
+msgstr "Введіть назву файлу вбудованого шрифту (напр., NotoSans-Bold.ttf) або псевдонім шрифту KOReader (напр., tfont, cfont). Якщо його не вдасться знайти, ця роль повернеться до свого типового шрифту."
 
 msgid ""
 "Enter a bundled font file name (e.g. NotoSans-Bold.ttf) or a KOReader font alias (e."
@@ -885,6 +897,9 @@ msgstr "Про програму"
 msgid "Reading insight"
 msgstr "Аналітика читання"
 
+msgid "A full-screen overlay with a comprehensive overview of your reading history, powered by KOReader's statistics database."
+msgstr "Повноекранний огляд з детальною статистикою вашої історії читання на основі бази даних статистики KOReader."
+
 msgid ""
 "A full-screen overlay with a comprehensive overview of your reading history, powered "
 "by KOReader's statistics database."
@@ -943,6 +958,9 @@ msgstr "Додаткові значення (дата / назва книги)"
 msgid "Reading goal section"
 msgstr "Розділ цілі читання"
 
+msgid "Shows the number of books finished this year next to your yearly goal. Long press the goal value to change it."
+msgstr "Показує кількість завершених цього року книжок поряд із вашою річною ціллю. Довге натискання на значення цілі дозволяє її змінити."
+
 msgid ""
 "Shows the number of books finished this year next to your yearly goal. Long press the "
 "goal value to change it."
@@ -970,6 +988,9 @@ msgstr "Продовжити редагування"
 
 msgid "Automatic"
 msgstr "Автоматично"
+
+msgid "Sizes the Reading insights bar charts so the page fits the screen without a scroll bar."
+msgstr "Підбирає розмір стовпчикових діаграм аналітики читання так, щоб сторінка вміщалася на екрані без смуги прокрутки."
 
 msgid ""
 "Sizes the Reading insights bar charts so the page fits the screen without a scroll "
@@ -1641,6 +1662,30 @@ msgstr "Ціль читання та досягнення"
 msgid "Reading goal only"
 msgstr "Лише ціль читання"
 
+msgid "Time of day"
+msgstr "Час доби"
+
+msgid "Time of day view"
+msgstr "Вигляд за часом доби"
+
+msgid "Chart"
+msgstr "Графік"
+
+msgid "Heatmap"
+msgstr "Теплова карта"
+
+msgid "Night"
+msgstr "Ніч"
+
+msgid "Morning"
+msgstr "Ранок"
+
+msgid "Afternoon"
+msgstr "День"
+
+msgid "Evening"
+msgstr "Вечір"
+
 msgid "Reading time by time of day"
 msgstr "Час читання за часом доби"
 
@@ -1667,3 +1712,12 @@ msgstr "Рядок «Розпочато / очікуване завершенн�
 
 msgid "Show the \"started …\" and \"expected finish\" date row in the \"Pace\" section."
 msgstr "Показати рядок дат «розпочато…» та «очікуване завершення» в розділі «Темп»."
+
+msgid "Hamburger menu"
+msgstr "Меню-гамбургер"
+
+msgid "Show the hamburger menu (top left of the title bar) with quick access to the streak, heatmap, records and achievements popups."
+msgstr "Показувати меню-гамбургер (у верхньому лівому куті панелі заголовка) зі швидким доступом до вікон серії читання, теплової карти, рекордів і досягнень."
+
+msgid "Couldn't open Records: "
+msgstr "Не вдалося відкрити Рекорди: "

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -294,6 +294,12 @@ msgstr "阅读时长"
 msgid "per day"
 msgstr "每日"
 
+msgid "second"
+msgstr "秒"
+
+msgid "seconds"
+msgstr "秒"
+
 msgid "minute"
 msgstr "分钟"
 msgid "minutes"
@@ -1324,6 +1330,30 @@ msgstr "阅读目标与成就"
 msgid "Reading goal only"
 msgstr "仅阅读目标"
 
+msgid "Time of day"
+msgstr "时段"
+
+msgid "Time of day view"
+msgstr "时段视图"
+
+msgid "Chart"
+msgstr "图表"
+
+msgid "Heatmap"
+msgstr "热力图"
+
+msgid "Night"
+msgstr "夜间"
+
+msgid "Morning"
+msgstr "上午"
+
+msgid "Afternoon"
+msgstr "下午"
+
+msgid "Evening"
+msgstr "晚上"
+
 msgid "Reading time by time of day"
 msgstr "各时段阅读时长"
 
@@ -1350,3 +1380,12 @@ msgstr "“开始 / 预计完成”行"
 
 msgid "Show the \"started …\" and \"expected finish\" date row in the \"Pace\" section."
 msgstr "在“阅读速度”区域显示“开始…”和“预计完成”日期行。"
+
+msgid "Hamburger menu"
+msgstr "汉堡菜单"
+
+msgid "Show the hamburger menu (top left of the title bar) with quick access to the streak, heatmap, records and achievements popups."
+msgstr "显示汉堡菜单（位于标题栏左上角），可快速打开连续阅读天数、热力图、记录和成就弹窗。"
+
+msgid "Couldn't open Records: "
+msgstr "无法打开记录："

--- a/main.lua
+++ b/main.lua
@@ -257,12 +257,23 @@ local StreakCalendar = loadModule("views/streak_calendar_view.lua", {
     Data = InsightsData, Prefs = Prefs,
 })
 
+-- Records: the queries and their cache (lib/records_data.lua, loaded above
+-- with the achievements wiring) are separate from the popup that draws them.
+-- Loaded here (moved up from below BookStatsData/BookCalendar) so the
+-- Records popup class can be handed to Insights below - the insights
+-- popup's hamburger menu opens it directly, the same way it already opens
+-- Streak/Heatmap/AchievementsView.
+local Records = loadModule("views/records_view.lua", {
+    Locale = Locale, Colors = Colors, Fonts = Fonts, PopupUtil = PopupUtil,
+    RecordsData = RecordsData,
+})
+
 local Insights = loadModule("views/insights_view.lua", {
     Locale = Locale, Colors = Colors, Fonts = Fonts,
     PopupUtil = PopupUtil, VS = ViewSettings, Cache = InsightsCache, UI = UI,
     Trend = Trend, Heatmap = Heatmap, BookList = BookList, Data = InsightsData,
     Manual = ManualBooks, Achievements = Achievements, AchievementsView = AchievementsView,
-    Prefs = Prefs, Streak = StreakCalendar,
+    Prefs = Prefs, Streak = StreakCalendar, Records = Records,
 })
 local BookCalendar = loadModule("views/book_calendar_view.lua", {
     Locale = Locale, Colors = Colors, Fonts = Fonts, Prefs = Prefs,
@@ -273,12 +284,6 @@ local StatsPopup = loadModule("views/book_stats_view.lua", {
     BookProgress = BookProgress, BookCalendar = BookCalendar,
     ChapterInfo = ChapterInfo, ChapterBar = ChapterBar, UI = UI,
     BookStatsData = BookStatsData, VS = ViewSettings,
-})
--- Records: the queries and their cache (lib/records_data.lua, loaded above
--- with the achievements wiring) are separate from the popup that draws them.
-local Records = loadModule("views/records_view.lua", {
-    Locale = Locale, Colors = Colors, Fonts = Fonts, PopupUtil = PopupUtil,
-    RecordsData = RecordsData,
 })
 local Updater = loadModule("lib/updater.lua", { Locale = Locale })
 local About   = loadModule("views/about.lua",

--- a/views/insights_view.lua
+++ b/views/insights_view.lua
@@ -70,10 +70,11 @@ local T = require("ffi/util").template
 -- loadModule() call for this file).
 -- Shared modules, passed in as one named table by main.lua (see there).
 local deps = ...
-local Locale, Colors, Fonts, PopupUtil, VS, Cache, UI, Trend, Heatmap, BookList, Data, Manual, Achievements, AchievementsView, Prefs, Streak =
+local Locale, Colors, Fonts, PopupUtil, VS, Cache, UI, Trend, Heatmap, BookList, Data, Manual, Achievements, AchievementsView, Prefs, Streak, Records =
     deps.Locale, deps.Colors, deps.Fonts, deps.PopupUtil,
     deps.VS, deps.Cache, deps.UI, deps.Trend, deps.Heatmap, deps.BookList,
-    deps.Data, deps.Manual, deps.Achievements, deps.AchievementsView, deps.Prefs, deps.Streak
+    deps.Data, deps.Manual, deps.Achievements, deps.AchievementsView, deps.Prefs, deps.Streak,
+    deps.Records
 
 -- true: today's bar in the weekly chart is black. false: all bars gray.
 local WEEKLY_CHART_HIGHLIGHT_TODAY = true
@@ -1056,18 +1057,9 @@ local function buildInsightsSections(popup_self, streaks, yearly_stats, year_ran
         local function openFinished()     popup_self:showFinishedBooksForYear(goal_year) end
         local function openFinishedMenu() popup_self:showFinishedBooksMenu(goal_year) end
         local function editGoal()         popup_self:editReadingGoal(goal_year) end
-        local function openAchievements()
-            if not AchievementsView then return end
-            -- Refresh the cell when the list closes, so the "new" star badge
-            -- clears at once (opening the list marks everything seen).
-            AchievementsView.show(function()
-                if popup_self._closed then return end
-                popup_self:_buildUI()
-                UIManager:setDirty(popup_self, function()
-                    return "ui", popup_self.popup_frame.dimen
-                end)
-            end)
-        end
+        -- Shared with the hamburger menu - see
+        -- ReadingInsightsPopup:openAchievementsList() above.
+        local function openAchievements() popup_self:openAchievementsList() end
 
         -- A value/label data cell (col_width wide) with a tap action.
         local function dataCell(line, on_tap)
@@ -1332,6 +1324,125 @@ end
 -- newer half-years as far back as there's data.
 function ReadingInsightsPopup:showReadingHeatmap()
     UIManager:show(Heatmap.Popup:new{ popup_self = self, periods_back = 0 })
+end
+
+-- Opens the achievements list. Shared by the reading-goal section's
+-- "Achievements" title/cell (see buildInsightsSections) and the hamburger
+-- menu (see onShowHamburgerMenu). Refreshes this popup's own build when the
+-- list closes, so the "new" star badge next to the earned count clears at
+-- once (opening the list marks everything seen).
+function ReadingInsightsPopup:openAchievementsList()
+    if not AchievementsView then return end
+    local popup_self = self
+    AchievementsView.show(function()
+        if popup_self._closed then return end
+        popup_self:_buildUI()
+        UIManager:setDirty(popup_self, function()
+            return "ui", popup_self.popup_frame.dimen
+        end)
+    end)
+end
+
+-- Opens the Records popup (all-time reading records) - same popup the
+-- Tools-menu "Show Records" entry opens (see main.lua's
+-- onShowReadingRecordsPopup), reachable here from the hamburger menu.
+function ReadingInsightsPopup:openRecordsPopup()
+    if not Records then return end
+    local popup_self = self
+    -- A first-ever open (no records cache yet) recomputes every record from
+    -- the full statistics history in one blocking scan - the plugin's own
+    -- slowest thing, and it runs on the UI thread (see records_view.lua's
+    -- onHold, which shows this same message before its own forced recount
+    -- for exactly that reason). Shown here too, so a big history doesn't
+    -- read as "nothing happened" while it's still counting - the message is
+    -- given a moment to actually reach the screen before the blocking call.
+    local msg = InfoMessage:new{ text = _("Loading data…") }
+    UIManager:show(msg)
+    UIManager:scheduleIn(0.1, function()
+        -- Wrapped in pcall: this is the one popup among the four
+        -- hamburger-menu entries that also touches the statistics database
+        -- on the way up (RecordsData.load()), so an InfoMessage here beats
+        -- a tap that silently does nothing if that ever throws instead of
+        -- returning its documented zero-value fallback.
+        local ok, err = pcall(function()
+            UIManager:show(Records.Popup:new{ ui = popup_self.ui })
+        end)
+        UIManager:close(msg)
+        if not ok then
+            UIManager:show(InfoMessage:new{
+                text = _("Couldn't open Records: ") .. tostring(err),
+            })
+        end
+    end)
+end
+
+-- Opens the combined current/best streak popup - same popup the streak
+-- header cells open (see buildInsightsSections) and the Tools-menu
+-- "Show Reading streak" entry (Insights.showStreaks below), reachable here
+-- from the hamburger menu. Uses whatever streak data this popup already
+-- has loaded rather than re-querying the DB.
+function ReadingInsightsPopup:openStreakPopup()
+    Streak.show(self._streaks or Data.calculateStreaks())
+end
+
+-- Hamburger menu (title bar, top left): quick access to the other reading-
+-- insights popups without paging/tapping through this one. Mirrors the
+-- sort-menu pattern used by the book-list popups (see
+-- widgets/booklistwidget.lua's onShowWidgetMenu / M.showSortMenu) - a
+-- ButtonDialog anchored under the title bar's left icon button.
+function ReadingInsightsPopup:onShowHamburgerMenu()
+    local ButtonDialog = require("ui/widget/buttondialog")
+    local popup_self = self
+    local dialog
+    local title_bar = self.title_bar
+    dialog = ButtonDialog:new{
+        -- This popup is itself modal, and UIManager stacks a non-modal
+        -- window shown over it underneath it - see showFinishedBooksMenu
+        -- above for the same reasoning.
+        modal                  = true,
+        shrink_unneeded_width  = true,
+        buttons = {
+            {{
+                text  = _("Show Reading streak"),
+                align = "left",
+                callback = function()
+                    UIManager:close(dialog)
+                    popup_self:openStreakPopup()
+                end,
+            }},
+            {{
+                text  = _("Show Reading heatmap"),
+                align = "left",
+                callback = function()
+                    UIManager:close(dialog)
+                    popup_self:showReadingHeatmap()
+                end,
+            }},
+            {{
+                text  = _("Show Records"),
+                align = "left",
+                callback = function()
+                    UIManager:close(dialog)
+                    popup_self:openRecordsPopup()
+                end,
+            }},
+            {{
+                text  = _("Show Achievements"),
+                align = "left",
+                callback = function()
+                    UIManager:close(dialog)
+                    popup_self:openAchievementsList()
+                end,
+            }},
+        },
+        -- Anchored under the title bar's hamburger icon, like the book
+        -- lists' sort menu - falls back to centred if that button isn't
+        -- there for some reason.
+        anchor = title_bar and title_bar.left_button and function()
+            return title_bar.left_button.image.dimen
+        end or nil,
+    }
+    UIManager:show(dialog)
 end
 
 -- Combines getFinishedBooksForYear's query-based list with the user's
@@ -1791,12 +1902,19 @@ function ReadingInsightsPopup:_buildUI()
             width          = screen_w,
             align          = "left",
             title          = self:_titleBarText(),
+            -- Hamburger menu, top left: quick access to the streak/heatmap/
+            -- records/achievements popups - see onShowHamburgerMenu below.
+            -- Hidden in readonly (sleep-screen) mode, same as close_callback,
+            -- so a stray touch there can't navigate away from the wake screen.
+            left_icon              = (not self.readonly and VS.Opt.readShowHamburgerMenu()) and "appbar.menu" or nil,
+            left_icon_tap_callback = (not self.readonly and VS.Opt.readShowHamburgerMenu()) and function() self:onShowHamburgerMenu() end or nil,
             close_callback = (not self.readonly) and function() UIManager:close(self) end or nil,
             show_parent    = self,
             top_v_padding    = Size.padding.default,
             bottom_v_padding = Size.padding.default,
         }
         self._title_bar_height = title_bar_inner:getSize().h
+        self.title_bar = title_bar_inner
 
         self.popup_frame = FrameContainer:new{
             background = Blitbuffer.COLOR_WHITE,
@@ -1853,6 +1971,12 @@ function ReadingInsightsPopup:_buildUI()
             width          = screen_w,
             align          = "left",
             title          = self:_titleBarText(),
+            -- Hamburger menu, top left: quick access to the streak/heatmap/
+            -- records/achievements popups - see onShowHamburgerMenu below.
+            -- Hidden in readonly (sleep-screen) mode, same as close_callback,
+            -- so a stray touch there can't navigate away from the wake screen.
+            left_icon              = (not self.readonly and VS.Opt.readShowHamburgerMenu()) and "appbar.menu" or nil,
+            left_icon_tap_callback = (not self.readonly and VS.Opt.readShowHamburgerMenu()) and function() self:onShowHamburgerMenu() end or nil,
             close_callback = (not self.readonly) and function() UIManager:close(self) end or nil,
             show_parent    = self,
             top_v_padding    = Size.padding.default,
@@ -1861,6 +1985,7 @@ function ReadingInsightsPopup:_buildUI()
 
         local title_bar_h = title_bar_inner:getSize().h
         self._title_bar_height = title_bar_h
+        self.title_bar = title_bar_inner
 
         -- Manual mode keeps the generous title-bar-tall bottom spacer it
         -- always had (the page is expected to scroll there anyway); auto


### PR DESCRIPTION
- Add hamburger menu (top-left of the title bar) with quick access to the Streak, Heatmap, Records, and Achievements popups
- Add Advanced settings toggle to show/hide it (default: off)
- Records popup now shows a loading message on first (uncached) open and surfaces errors instead of failing silently
- Sync de.po, uk.po, pt_PT.po, fr.po, zh_CN.po with hu.po (add missing strings, including the new hamburger menu translations)